### PR TITLE
SU-6329: Manual Availability monitoring works correctly in environments that have more than 2 management servers

### DIFF
--- a/ManagementPacks/SquaredUp.EAM.Library/ManualAvailability/SquaredUp.EAM.Library.WriteAction.ManualAvailability.StartEventTask.ps1
+++ b/ManagementPacks/SquaredUp.EAM.Library/ManualAvailability/SquaredUp.EAM.Library.WriteAction.ManualAvailability.StartEventTask.ps1
@@ -1,0 +1,58 @@
+﻿param(
+	$ManagedEntityId, 
+	$State, 
+	$Description, 
+	$DisplayName, 
+	$ManagementServer, 
+	$SetByUser
+)
+
+$scriptName = "SquaredUp.EAM.Library.WriteAction.ManualAvailability.StartEventTask.ps1"
+
+$momapi = New-Object -comObject MOM.ScriptAPI
+$momapi.LogScriptEvent($scriptName,8998,0,"`n Script is starting. `n Attempting to trigger health state change to '$State' with description '$Description' for '$DisplayName' on $ManagementServer")
+
+Import-Module OperationsManager
+
+$ms = Get-SCOMClassInstance -Id $ManagementServer
+
+$task = Get-SCOMTask -Id "$MPElement[Name='SquaredUp.EAM.Library.AgentTask.ManualAvailability.MS.Unhealthy']$"
+
+$overrides = @{
+	"State"=$State
+	"Description"=$Description
+	"ManagedEntityId"=$ManagedEntityId
+	"TargetDisplayName"=$DisplayName
+	"SetByUser"=$SetByUser
+}
+
+$momapi.LogScriptEvent($scriptName,8998,0,"Triggering task to set health for '$DisplayName'")
+$taskOut = Start-SCOMTask -task $task -instance $ms -Override $overrides
+
+if ($taskOut.BatchId -ne $null){
+
+	$results = $null
+	$momapi.LogScriptEvent($scriptName,8998,0,"Polling for results...")
+
+	while ($results -eq $null){
+		
+		$currentState = Get-SCOMTaskResult -BatchID $taskOut.BatchId
+
+		if ($currentState.TimeFinished -ne $null){
+			$results = $currentState
+		}
+		else{
+			Start-Sleep -Milliseconds 300
+		}
+	}
+}
+
+if ($results.status -eq 'Succeeded'){
+	Write-Host $results.Status
+}
+else {
+	Throw "Task failed with state '$($results.Status)', error: $($results.ErrorCode) $($results.ErrorMessage)"
+}
+
+
+$momapi.LogScriptEvent($scriptName,8998,0,"`n Script is Complete.")

--- a/ManagementPacks/SquaredUp.EAM.Library/ManualAvailability/Task.CreateEvent.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Library/ManualAvailability/Task.CreateEvent.mpx
@@ -16,10 +16,16 @@
             </xsd:simpleType>
           </xsd:element>
           <xsd:element name="Description" type="xsd:string" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element name="ManagedEntityId" type="xsd:string" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element name="TargetDisplayName" type="xsd:string" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element name="SetByUser" type="xsd:string" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
           <OverrideableParameter ID="State" Selector="$Config/State$" ParameterType="string" />
           <OverrideableParameter ID="Description" Selector="$Config/Description$" ParameterType="string" />
+          <OverrideableParameter ID="ManagedEntityId" Selector="$Config/ManagedEntityId$" ParameterType="string"/>
+          <OverrideableParameter ID="TargetDisplayName" Selector="$Config/TargetDisplayName$" ParameterType="string" />
+          <OverrideableParameter ID="SetByUser" Selector="$Config/SetByUser$" ParameterType="string"/>
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
@@ -27,18 +33,22 @@
               <ProbeAction ID="CreatePropertyBag" TypeID="Windows!Microsoft.Windows.PowerShellPropertyBagProbe">
                 <ScriptName>SquaredUp.EAM.Library.WriteAction.ManualAvailability.PublishToChannel.ps1</ScriptName>
                 <ScriptBody>
-                  param($ManagedEntityId, $State, $Description)
+                  param($ManagedEntityId, $State, $Description, $SetByUser = "")
                   $momapi = New-Object -comObject MOM.ScriptAPI
+                  $scriptName = "SquaredUp.EAM.Library.WriteAction.ManualAvailability.PublishToChannel.ps1"
+                  $momapi.LogScriptEvent($scriptName,8999,0,"`n Script is starting. `n Attempting to set health state to '$State' with description '$Description' for $Config/TargetDisplayName$")
                   $bag = $momapi.CreatePropertyBag()
                   $bag.AddValue( "ManagedEntityId", $ManagedEntityId)
                   $bag.AddValue( "State", "$State".ToLower().Trim() )
                   $bag.AddValue( "Description" , $Description )
+                  $bag.AddValue( "SetByUser", $SetByUser )
                   $bag
+                  $momapi.LogScriptEvent($scriptName,8999,0,"`n Script is Complete.")
                 </ScriptBody>
                 <Parameters>
                   <Parameter>
                     <Name>ManagedEntityId</Name>
-                    <Value>$Target/Id$</Value>
+                    <Value>$Config/ManagedEntityId$</Value>
                   </Parameter>
                   <Parameter>
                     <Name>State</Name>
@@ -47,6 +57,10 @@
                   <Parameter>
                     <Name>Description</Name>
                     <Value>$Config/Description$</Value>
+                  </Parameter>
+                  <Parameter>
+                    <Name>SetByUser</Name>
+                    <Value>$Config/SetByUser$</Value>
                   </Parameter>
                 </Parameters>
                 <TimeoutSeconds>60</TimeoutSeconds>
@@ -64,7 +78,7 @@
               </ConditionDetection>
               <WriteAction ID="Publish" TypeID="System!System.PublishData">
                 <ManagementGroupId>$Target/ManagementGroup/Id$</ManagementGroupId>
-                <ChannelId>$Target/Id$</ChannelId>
+                <ChannelId>$Config/ManagedEntityId$</ChannelId>
               </WriteAction>
             </MemberModules>
             <Composition>
@@ -78,25 +92,7 @@
         </ModuleImplementation>
         <InputType>System!System.BaseData</InputType>
       </WriteActionModuleType>
-      
-    <WriteActionModuleType ID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.PublishToChannel.Healthy" Accessibility="Internal" Batching="false">
-          <Configuration />
-          <ModuleImplementation Isolation="Any">
-          <Composite>
-            <MemberModules>
-              <WriteAction ID="Publish" TypeID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.PublishToChannel">
-                <State>success</State>
-                <Description></Description>
-              </WriteAction>
-            </MemberModules>
-            <Composition>
-              <Node ID="Publish" />
-            </Composition>
-          </Composite>
-        </ModuleImplementation>
-        <InputType>System!System.BaseData</InputType>
-      </WriteActionModuleType>
-     
+
     </ModuleTypes>
 
   </TypeDefinitions>
@@ -104,20 +100,18 @@
   <Monitoring>
 
     <Tasks>
-      
-      <Task ID="SquaredUp.EAM.Library.AgentTask.ManualAvailability.Healthy" Accessibility="Internal" Target="SquaredUp.EAM.Library.Class.EnterpriseApplication.Base" Enabled="true" Remotable="true" Timeout="90">
-        <Category>Custom</Category>
-        <WriteAction ID="Publish" TypeID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.PublishToChannel.Healthy" />
-      </Task>
-        
-      <Task ID="SquaredUp.EAM.Library.AgentTask.ManualAvailability.Unhealthy" Accessibility="Internal" Target="SquaredUp.EAM.Library.Class.EnterpriseApplication.Base" Enabled="true" Remotable="true" Timeout="90">
+
+      <Task ID="SquaredUp.EAM.Library.AgentTask.ManualAvailability.MS.Unhealthy" Accessibility="Internal" Target="SC!Microsoft.SystemCenter.ManagementServer" Enabled="true" Remotable="true" Timeout="90" >
         <Category>Custom</Category>
         <WriteAction ID="Publish" TypeID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.PublishToChannel">
           <State>error</State>
           <Description>No description of the status was supplied.</Description>
+          <ManagedEntityId></ManagedEntityId>
+          <TargetDisplayName></TargetDisplayName>
+          <SetByUser></SetByUser>
         </WriteAction>
       </Task>
-    
+
     </Tasks>
 
   </Monitoring>
@@ -125,7 +119,7 @@
   <LanguagePacks>
     <LanguagePack ID="ENU" IsDefault="true">
       <DisplayStrings>
-        
+
         <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.PublishToChannel">
           <Name>Publish status to channel</Name>
           <Description>Publishes a propertybag that indicates current manual health state.</Description>
@@ -141,19 +135,24 @@
           <Description>Any context or details you wish to provide with this health state update.</Description>
         </DisplayString>
 
-        <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.PublishToChannel.Healthy">
-          <Name>Publish status to channel (healthy)</Name>
-          <Description>Publishes a propertybag that indicates a healthy manual state.</Description>
+        <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.PublishToChannel" SubElementID="ManagedEntityId">
+          <Name>Enterprise Application Id</Name>
+          <Description>The SCOM GUID for the Enterprise Application you wish to set state for.</Description>
         </DisplayString>
 
-        <DisplayString ElementID="SquaredUp.EAM.Library.AgentTask.ManualAvailability.Healthy">
-          <Name>Set availability healthy</Name>
-          <Description>Set the availability state of the application to healthy.</Description>
+        <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.PublishToChannel" SubElementID="TargetDisplayName">
+          <Name>Enterprise Application DisplayName</Name>
+          <Description>The name of the Enterprise Application you wish to set state for.</Description>
         </DisplayString>
 
-        <DisplayString ElementID="SquaredUp.EAM.Library.AgentTask.ManualAvailability.Unhealthy">
-          <Name>Set availability unhealthy</Name>
-          <Description>Set the availability state of the application. State can be 'Success', 'Warning' or 'Error'.</Description>
+        <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.PublishToChannel" SubElementID="SetByUser">
+          <Name>Set By User</Name>
+          <Description>The user who set this state change or reported the status.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Library.AgentTask.ManualAvailability.MS.Unhealthy">
+          <Name>Set Enterprise Application End-User Reporting Health</Name>
+          <Description>Set the availability state of an application. State can be 'Success', 'Warning' or 'Error'.</Description>
         </DisplayString>
 
       </DisplayStrings>

--- a/ManagementPacks/SquaredUp.EAM.Library/ManualAvailability/Task.CreateEvent.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Library/ManualAvailability/Task.CreateEvent.mpx
@@ -136,17 +136,17 @@
         </DisplayString>
 
         <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.PublishToChannel" SubElementID="ManagedEntityId">
-          <Name>Enterprise Application Id</Name>
+          <Name>Enterprise Application ID</Name>
           <Description>The SCOM GUID for the Enterprise Application you wish to set state for.</Description>
         </DisplayString>
 
         <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.PublishToChannel" SubElementID="TargetDisplayName">
-          <Name>Enterprise Application DisplayName</Name>
+          <Name>Enterprise Application Display Name</Name>
           <Description>The name of the Enterprise Application you wish to set state for.</Description>
         </DisplayString>
 
         <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.PublishToChannel" SubElementID="SetByUser">
-          <Name>Set By User</Name>
+          <Name>Set by User</Name>
           <Description>The user who set this state change or reported the status.</Description>
         </DisplayString>
 

--- a/ManagementPacks/SquaredUp.EAM.Library/ManualAvailability/Task.LocateManagementServer.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Library/ManualAvailability/Task.LocateManagementServer.mpx
@@ -150,7 +150,7 @@
         </DisplayString>
 
         <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.LocateManagementServer" SubElementID="SetByUser">
-          <Name>Set By User</Name>
+          <Name>Set by User</Name>
           <Description>The user who set this state change or reported the status.</Description>
         </DisplayString>
 
@@ -165,12 +165,12 @@
         </DisplayString>
 
         <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.LocateManagementServer.Healthy" SubElementID="SetByUser">
-          <Name>Set By User</Name>
+          <Name>Set by User</Name>
           <Description>The user who set this state change or reported the status.</Description>
         </DisplayString>
 
         <DisplayString ElementID="SquaredUp.EAM.Library.AgentTask.ManualAvailability.Healthy"> 
-          <Name>Set availability healthy</Name>
+          <Name>Set Availability Healthy</Name>
           <Description>Set the availability state of the application to healthy.</Description>
         </DisplayString>
 

--- a/ManagementPacks/SquaredUp.EAM.Library/ManualAvailability/Task.LocateManagementServer.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Library/ManualAvailability/Task.LocateManagementServer.mpx
@@ -1,0 +1,187 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <TypeDefinitions>
+
+    <ModuleTypes>
+
+      <WriteActionModuleType ID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.LocateManagementServer" Accessibility="Internal" >
+        <Configuration>
+          <xsd:element name="State" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="success"/>
+                <xsd:enumeration value="warning"/>
+                <xsd:enumeration value="error"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:element>
+          <xsd:element name="Description" type="xsd:string" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element name="SetByUser" type="xsd:string" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+        </Configuration>
+        <OverrideableParameters>
+          <OverrideableParameter ID="State" Selector="$Config/State$" ParameterType="string" />
+          <OverrideableParameter ID="Description" Selector="$Config/Description$" ParameterType="string" />
+          <OverrideableParameter ID="SetByUser" Selector="$Config/SetByUser$" ParameterType="string" />
+        </OverrideableParameters>
+        <ModuleImplementation Isolation="Any">
+          <Composite>
+            <MemberModules>
+              <ProbeAction ID="Lookup" TypeID="SC!Microsoft.SystemCenter.GetPoolMemberMonitoringTLME.CompositeProbe">
+                <PoolId>$MPElement[Name="SC!Microsoft.SystemCenter.AllManagementServersPool"]$</PoolId>
+                <ManagedEntityId>$Target/Id$</ManagedEntityId>
+              </ProbeAction>
+              <WriteAction ID="StartEventTask" TypeID="Windows!Microsoft.Windows.PowerShellWriteAction">
+                <ScriptName>SquaredUp.EAM.Library.WriteAction.ManualAvailability.StartEventTask.ps1</ScriptName>
+                <ScriptBody>$IncludeFileContent/ManualAvailability/SquaredUp.EAM.Library.WriteAction.ManualAvailability.StartEventTask.ps1$</ScriptBody>
+                <Parameters>
+                  <Parameter>
+                    <Name>ManagedEntityId</Name>
+                    <Value>$Target/Id$</Value>
+                  </Parameter>
+                  <Parameter>
+                    <Name>State</Name>
+                    <Value>$Config/State$</Value>
+                  </Parameter>
+                  <Parameter>
+                    <Name>Description</Name>
+                    <Value>$Config/Description$</Value>
+                  </Parameter>
+                  <Parameter>
+                    <Name>DisplayName</Name>
+                    <Value>$Target/Property[Type="System!System.Entity"]/DisplayName$</Value>
+                  </Parameter>
+                  <Parameter>
+                    <Name>ManagementServer</Name>
+                    <Value>$Data/ManagingHealthService/@healthServiceId$</Value>
+                  </Parameter>
+                  <Parameter>
+                    <Name>SetByUser</Name>
+                    <Value>$Config/SetByUser$</Value>
+                  </Parameter>
+                </Parameters>
+                <TimeoutSeconds>60</TimeoutSeconds>
+                <StrictErrorHandling>true</StrictErrorHandling>
+              </WriteAction>
+            </MemberModules>
+            <Composition>
+              <Node ID="StartEventTask">
+                <Node ID="Lookup" />
+              </Node>
+            </Composition>
+          </Composite>
+        </ModuleImplementation>
+        <OutputType>Windows!Microsoft.Windows.SerializedObjectData</OutputType>
+        <InputType>System!System.BaseData</InputType>
+      </WriteActionModuleType>
+
+      <WriteActionModuleType ID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.LocateManagementServer.Healthy" Accessibility="Internal" >
+        <Configuration>
+          <xsd:element name="Description" type="xsd:string" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element name="SetByUser" type="xsd:string" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+        </Configuration>
+        <OverrideableParameters>
+          <OverrideableParameter ID="Description" Selector="$Config/Description$" ParameterType="string" />
+          <OverrideableParameter ID="SetByUser" Selector="$Config/SetByUser$" ParameterType="string"/>
+        </OverrideableParameters>
+        <ModuleImplementation Isolation="Any">
+          <Composite>
+            <MemberModules>
+              <WriteAction ID="SetHealthy" TypeID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.LocateManagementServer" >
+                <State>success</State>
+                <Description>$Config/Description$</Description>
+                <SetByUser></SetByUser>
+              </WriteAction>
+            </MemberModules>
+            <Composition>
+              <Node ID="SetHealthy" />
+            </Composition>
+          </Composite>
+        </ModuleImplementation>
+        <OutputType>Windows!Microsoft.Windows.SerializedObjectData</OutputType>
+        <InputType>System!System.BaseData</InputType>
+      </WriteActionModuleType>
+
+    </ModuleTypes>
+
+  </TypeDefinitions>
+
+  <Monitoring>
+
+    <Tasks>
+      
+      <Task ID="SquaredUp.EAM.Library.AgentTask.ManualAvailability.Healthy" Accessibility="Internal" Target="SquaredUp.EAM.Library.Class.EnterpriseApplication.Base" Enabled="true" Remotable="true" Timeout="90" RunLocation="SC!Microsoft.SystemCenter.CollectionManagementServer">
+        <Category>Custom</Category>
+        <WriteAction ID="Publish" TypeID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.LocateManagementServer.Healthy" >
+          <Description></Description>
+          <SetByUser></SetByUser>
+        </WriteAction>
+      </Task>
+        
+      <Task ID="SquaredUp.EAM.Library.AgentTask.ManualAvailability.Unhealthy" Accessibility="Internal" Target="SquaredUp.EAM.Library.Class.EnterpriseApplication.Base" Enabled="true" Remotable="true" Timeout="90" RunLocation="SC!Microsoft.SystemCenter.CollectionManagementServer">
+        <Category>Custom</Category>
+        <WriteAction ID="Publish" TypeID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.LocateManagementServer">
+          <State>error</State>
+          <Description>No description of the status was supplied.</Description>
+          <SetByUser></SetByUser>
+        </WriteAction>
+      </Task>
+    
+    </Tasks>
+
+  </Monitoring>
+
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.LocateManagementServer">
+          <Name>Locate and trigger create event task write action</Name>
+          <Description>Locate the management server in the resource pool that is currently managing the target, and trigger the Create Event task on that server.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.LocateManagementServer" SubElementID="State">
+          <Name>State</Name>
+          <Description>The state to publish. Should be success|warning|error.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.LocateManagementServer" SubElementID="Description">
+          <Name>Description</Name>
+          <Description>Any context or details you wish to provide with this health state update.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.LocateManagementServer" SubElementID="SetByUser">
+          <Name>Set By User</Name>
+          <Description>The user who set this state change or reported the status.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.LocateManagementServer.Healthy">
+          <Name>Locate and trigger create healthy event task write action</Name>
+          <Description>Locate the management server in the resource pool that is currently managing the target, and trigger the Create Event task on that server.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.LocateManagementServer.Healthy" SubElementID="Description">
+          <Name>Description</Name>
+          <Description>Any context or details you wish to provide with this health state update.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Library.WriteAction.ManualAvailability.LocateManagementServer.Healthy" SubElementID="SetByUser">
+          <Name>Set By User</Name>
+          <Description>The user who set this state change or reported the status.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Library.AgentTask.ManualAvailability.Healthy"> 
+          <Name>Set availability healthy</Name>
+          <Description>Set the availability state of the application to healthy.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Library.AgentTask.ManualAvailability.Unhealthy">
+          <Name>Report Availability</Name>
+          <Description>Set the availability state of the application. State can be 'Success', 'Warning' or 'Error'.</Description>
+        </DisplayString>
+
+      </DisplayStrings>
+      <KnowledgeArticles></KnowledgeArticles>
+    </LanguagePack>
+  </LanguagePacks>
+
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Library/SquaredUp.EAM.Library.mpproj
+++ b/ManagementPacks/SquaredUp.EAM.Library/SquaredUp.EAM.Library.mpproj
@@ -44,6 +44,7 @@
     <ManagementPackReference Include="Microsoft.SystemCenter.Library">
       <Alias>SC</Alias>
       <MinVersion>7.0.8427.0</MinVersion>
+      <PackageToBundle>False</PackageToBundle>
     </ManagementPackReference>
     <ManagementPackReference Include="System.Library">
       <Alias>System</Alias>
@@ -138,6 +139,9 @@
     <Compile Include="ManagementPack.mpx">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="ManualAvailability\Task.CreateEvent.mpx">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Modules\Datasource.DiscoveryProvider.mpx">
       <SubType>Code</SubType>
     </Compile>
@@ -168,7 +172,7 @@
     <Compile Include="ManualAvailability\Monitor.mpx">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="ManualAvailability\Task.mpx">
+    <Compile Include="ManualAvailability\Task.LocateManagementServer.mpx">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Service Model\Classes\Availability.mpx">
@@ -269,6 +273,7 @@
     <EmbeddedResource Include="AvailabilityMonitoring\Monitors\Shared\Scripts\SquaredUp.EAM.AvailabilityMonitoring.Web.Basic.Monitor.DataSource.ps1" />
     <EmbeddedResource Include="AvailabilityMonitoring\Monitors\Types\Tcp\Scripts\TcpTest.ps1" />
     <EmbeddedResource Include="AvailabilityMonitoring\Monitors\Types\Web\Scripts\WebTest.ps1" />
+    <EmbeddedResource Include="ManualAvailability\SquaredUp.EAM.Library.WriteAction.ManualAvailability.StartEventTask.ps1" />
     <EmbeddedResource Include="Modules\Scripts\SquaredUp.EAM.Discovery.ps1" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VSAC\Microsoft.SystemCenter.OperationsManager.targets" />


### PR DESCRIPTION
## Synopsis

Publish to channel task now run on management server currently handling monitoring workflows for an entity.

## Description

Currently the _Report Availability_ functionality of EAM Plus relies on this management pack to actually impact the health state. In order for this to work, the _Publish_ events must be written on the same management server that is currently executing the monitoring workflow (_subscriber_ module), otherwise nothing handles the arrival of the trace event and the task times out.

In single management server environments this functions correctly 100% of the time.  In two management server environments this seems to arbitrarily function in some management groups (3 of our development environments are fine) but will fail or work intermittently in others (in our demo environment, this only works 1/3 times).  In management groups that feature a large number of management servers (13 in one instance) it virtually never works.

It would appear that whilst monitoring workflows are all assigned to the same health service managing an entity on a pool, *AgentTasks* are not.

This PR attempts to resolve this by moving to a two task process - when a user triggers a Report Availability task the initial (parent) task runs, and locates which management server on the pool is currently managing the targeted EA.  This then triggers a script which starts a second (child) task which is targeted not at Enterprise Applications, but *Management Servers*.  This allows us to control precisely where it executes.  The child task just publishes a trace event as before, and the parent task only completes to the original caller after the child task has.

As a bonus, I've also exposed a new (optional) field in the property bag that allows you to mark who requested/set the status.  It's not set via the UI right now as that would require a (minor) product change, but it's available from the _Tasks_ action in Squared Up if really crucial.

## Testing

As this is a purely management pack level change, nothing has changed in the product so any regressions will be around the task interface (triggering, reporting of results) and behaviour.

Runtimes seem to vary now between 3-20 seconds, but this is likely due to environmental factors and SDK warmup (the bulk of the time is all spent triggering the child task).  As the child task executes as the MS default action account, no role changes are required (operators who were only scoped to the same task before will still only need to run the parent as required).