### PR TITLE
SU-6084: Watcher nodes correctly undiscover when no longer in scope of AllEAMTestGroups override

### DIFF
--- a/ManagementPacks/SquaredUp.EAM.Library/AvailabilityMonitoring/Classes/ApplicationAvailabilityMonitoringNode.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Library/AvailabilityMonitoring/Classes/ApplicationAvailabilityMonitoringNode.mpx
@@ -13,13 +13,15 @@
   <Monitoring>
     
     <Discoveries>
-      <Discovery ID="SquaredUp.EAM.Library.Discovery.AvailabilityMonitoring.MonitoringNode" Target="Windows!Microsoft.Windows.Server.OperatingSystem" Enabled="false" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+      <Discovery ID="SquaredUp.EAM.Library.Discovery.AvailabilityMonitoring.MonitoringNode" Target="Windows!Microsoft.Windows.Server.OperatingSystem" Enabled="true" ConfirmDelivery="false" Remotable="true" Priority="Normal">
 	    <Category>Discovery</Category>
         <DiscoveryTypes>
 			<DiscoveryClass TypeID="SquaredUp.EAM.Library.Class.AvailabilityMonitoring.MonitoringNode" />
         </DiscoveryTypes>
-        <DataSource ID="DS" TypeID="SquaredUp.EAM.Library.DataSource.AvailabilityMonitoring.StaticDiscovery">
+        <DataSource ID="DS" TypeID="SquaredUp.EAM.Library.DataSource.AvailabilityMonitoring.StaticAlwaysOnDiscovery">
           <IntervalSeconds>86400</IntervalSeconds>
+          <DiscoverInstance>false</DiscoverInstance>
+          <ComputerName>$Target/Host/Property[Type='Windows!Microsoft.Windows.Computer']/PrincipalName$</ComputerName>
           <ClassId>$MPElement[Name="SquaredUp.EAM.Library.Class.AvailabilityMonitoring.MonitoringNode"]$</ClassId>
           <InstanceSettings>
             <Settings>
@@ -49,7 +51,7 @@
         </DisplayString>
         <DisplayString ElementID="SquaredUp.EAM.Library.Discovery.AvailabilityMonitoring.MonitoringNode">
           <Name>Discover Enterprise Application Availability Monitoring Nodes</Name>
-          <Description>This discovery is disabled by default, and if enabled will mark the target server as an Application availability monitoring node.</Description>
+          <Description>This discovery is enabled by default, and if DiscoverInstance is set to true will mark the target server as an Application availability monitoring node.</Description>
         </DisplayString>
       </DisplayStrings>
       <KnowledgeArticles>
@@ -58,7 +60,7 @@
           <MamlContent>
             <maml:section xmlns:maml="http://schemas.microsoft.com/maml/2004/10">
               <maml:title>Summary</maml:title>
-              <maml:para>This discovery is disabled by default, and if enabled will mark the target server as an Application availability monitoring node.</maml:para>
+              <maml:para>This discovery is enabled by default, and if DiscoverInstance is set to true will mark the target server as an Application availability monitoring node.</maml:para>
             </maml:section>
           </MamlContent>
         </KnowledgeArticle>

--- a/ManagementPacks/SquaredUp.EAM.Library/AvailabilityMonitoring/Classes/StaticAlwaysOnDiscoveryDataSource.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Library/AvailabilityMonitoring/Classes/StaticAlwaysOnDiscoveryDataSource.mpx
@@ -1,0 +1,106 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <TypeDefinitions>
+
+    <ModuleTypes>
+      <DataSourceModuleType ID="SquaredUp.EAM.Library.DataSource.AvailabilityMonitoring.StaticAlwaysOnDiscovery" Accessibility="Public">
+        <Configuration>
+          <IncludeSchemaTypes>
+            <SchemaType>System!System.ExpressionEvaluatorSchema</SchemaType>
+            <SchemaType>System!System.Discovery.MapperSchema</SchemaType>
+          </IncludeSchemaTypes>
+          <xsd:element name="IntervalSeconds" type="xsd:integer" />
+          <xsd:element name="SyncTime" type="xsd:string" minOccurs="0" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element name="DiscoverInstance" type="xsd:boolean" />
+          <xsd:element name="ComputerName" type="xsd:string" />
+          <xsd:element name="ClassId" type="xsd:string"/>
+          <xsd:element name="InstanceSettings" minOccurs="0" maxOccurs="1" type="SettingsType"/>
+        </Configuration>
+        <OverrideableParameters>
+          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="SyncTime" Selector="$Config/SyncTime$" ParameterType="string" />
+          <OverrideableParameter ID="DiscoverInstance" Selector="$Config/DiscoverInstance$" ParameterType="bool" />
+        </OverrideableParameters>
+        <ModuleImplementation Isolation="Any">
+          <Composite>
+            <MemberModules>
+              <DataSource ID="Scheduler" TypeID="System!System.Discovery.Scheduler">
+                <Scheduler>
+                  <SimpleReccuringSchedule>
+                    <Interval Unit="Seconds">$Config/IntervalSeconds$</Interval>
+                    <SyncTime>$Config/SyncTime$</SyncTime>
+                  </SimpleReccuringSchedule>
+                  <ExcludeDates />
+                </Scheduler>
+              </DataSource>
+              <ProbeAction ID="Registry" TypeID="Windows!Microsoft.Windows.RegistryProbe" Comment="Only required to post a logical set of DataItems to force the following Expression filter to output 0 items in the case of a non-match." >
+                <ComputerName>$Config/ComputerName$</ComputerName>
+                <RegistryAttributeDefinitions>
+                  <RegistryAttributeDefinition>
+                    <AttributeName>KeyExists</AttributeName>
+                    <Path>SOFTWARE\Microsoft</Path>
+                    <PathType>0</PathType>
+                    <AttributeType>0</AttributeType>
+                  </RegistryAttributeDefinition>
+                </RegistryAttributeDefinitions>
+              </ProbeAction>
+              <ConditionDetection ID="Mapper" TypeID="System!System.Discovery.FilteredClassSnapshotDataMapper">
+                <Expression>
+                  <SimpleExpression>
+                    <ValueExpression>
+                      <Value Type="Boolean">$Config/DiscoverInstance$</Value>
+                    </ValueExpression>
+                    <Operator>Equal</Operator>
+                    <ValueExpression>
+                      <Value Type="Boolean">true</Value>
+                    </ValueExpression>
+                  </SimpleExpression>
+                </Expression>
+                <ClassId>$Config/ClassId$</ClassId>
+                <InstanceSettings>$Config/InstanceSettings$</InstanceSettings>
+              </ConditionDetection>
+            </MemberModules>
+            <Composition>
+              <Node ID="Mapper">
+                <Node ID="Registry">
+                  <Node ID="Scheduler"/>
+                </Node>
+              </Node>
+            </Composition>
+          </Composite>
+        </ModuleImplementation>
+        <OutputType>System!System.Discovery.Data</OutputType>
+      </DataSourceModuleType>
+    </ModuleTypes>
+
+  </TypeDefinitions>
+
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        <DisplayString ElementID="SquaredUp.EAM.Library.DataSource.AvailabilityMonitoring.StaticAlwaysOnDiscovery">
+          <Name>Enterprise Application Availability Monitoring Static Always On Discovery</Name>
+          <Description>Uses a FilteredClassSnapshotDataMapper to discover instances against the workflow target, assuming a flag (typically overridden) is set.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Library.DataSource.AvailabilityMonitoring.StaticAlwaysOnDiscovery" SubElementID="IntervalSeconds">
+          <Name>Interval (Seconds)</Name>
+          <Description>The number of seconds between discovery attempts.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Library.DataSource.AvailabilityMonitoring.StaticAlwaysOnDiscovery" SubElementID="SyncTime">
+          <Name>Sync Time (hh:mm)</Name>
+          <Description>The time around which discovery attempts will be synchronized.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Library.DataSource.AvailabilityMonitoring.StaticAlwaysOnDiscovery" SubElementID="DiscoverInstance">
+          <Name>Discover Instance</Name>
+          <Description>If true, an instance will be discovered.</Description>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+
+  </LanguagePacks>
+
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Library/AvailabilityMonitoring/Groups/TestGroups.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Library/AvailabilityMonitoring/Groups/TestGroups.mpx
@@ -42,10 +42,10 @@
     
     <Overrides>
       
-      <DiscoveryPropertyOverride ID="SquaredUp.EAM.Library.Override.ApplicationAvailabilityMonitoringNode.DisableDiscovery" Context="SquaredUp.EAM.Library.Group.AvailabilityMonitoring.AllEAMTestGroups" Enforced="false" Discovery="SquaredUp.EAM.Library.Discovery.AvailabilityMonitoring.MonitoringNode" Property="Enabled">
+      <DiscoveryConfigurationOverride ID="SquaredUp.EAM.Library.Override.ApplicationAvailabilityMonitoringNode.EnableDiscovery" Context="SquaredUp.EAM.Library.Group.AvailabilityMonitoring.AllEAMTestGroups" Enforced="false" Discovery="SquaredUp.EAM.Library.Discovery.AvailabilityMonitoring.MonitoringNode" Module="DS" Parameter="DiscoverInstance">
         <Value>true</Value>
-      </DiscoveryPropertyOverride>
-      
+      </DiscoveryConfigurationOverride>
+
     </Overrides>
     
   </Monitoring>

--- a/ManagementPacks/SquaredUp.EAM.Library/SquaredUp.EAM.Library.mpproj
+++ b/ManagementPacks/SquaredUp.EAM.Library/SquaredUp.EAM.Library.mpproj
@@ -6,7 +6,7 @@
     <RootNamespace>SquaredUp.EAM.Library</RootNamespace>
     <Name>SquaredUp.EAM.Library</Name>
     <ManagementPackName>SquaredUp.EAM.Library</ManagementPackName>
-    <Version>1.2.3.5</Version>
+    <Version>1.0.0.0</Version>
     <MpFrameworkVersion>v7.0</MpFrameworkVersion>
     <MpFrameworkProfile>OM</MpFrameworkProfile>
     <ProductVersion>1.1.0.0</ProductVersion>

--- a/ManagementPacks/SquaredUp.EAM.Library/SquaredUp.EAM.Library.mpproj
+++ b/ManagementPacks/SquaredUp.EAM.Library/SquaredUp.EAM.Library.mpproj
@@ -6,7 +6,7 @@
     <RootNamespace>SquaredUp.EAM.Library</RootNamespace>
     <Name>SquaredUp.EAM.Library</Name>
     <ManagementPackName>SquaredUp.EAM.Library</ManagementPackName>
-    <Version>1.0.0.0</Version>
+    <Version>1.2.3.5</Version>
     <MpFrameworkVersion>v7.0</MpFrameworkVersion>
     <MpFrameworkProfile>OM</MpFrameworkProfile>
     <ProductVersion>1.1.0.0</ProductVersion>
@@ -80,6 +80,9 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="AvailabilityMonitoring\Classes\ApplicationAvailabilityWatcher.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="AvailabilityMonitoring\Classes\StaticAlwaysOnDiscoveryDataSource.mpx">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="AvailabilityMonitoring\Classes\StaticDiscoveryDataSource.mpx">


### PR DESCRIPTION
This PR attempts to resolve issues with EA Availability watcher discovery:

1. When machines are no longer in scope of the AllEAMTestGroups override, instances of the Watcher Node class are not removed.
2. When the EA test group is changed, instances of the test class are not removed from nodes in the previous group.
3. When a node is removed from an EA test group, instances of the test class are not removed from that node.

The root cause of all three issues of the same - "undiscovery" cannot occur if the discovery does not run (because it is disabled), and because the discoveries in question are disabled by _default_ they are not correctly processed by the `Remove-SCOMDisabledClassInstance` cmdlet even if a admin does manually run it after EA watcher change (which does not scale).

In order to resolve this, I've added a new module to replace the `StaticDiscovery` datasource (the old one is still present because of SCOM backwards compatibility constraints, and to ensure existing EAs remain working).  The `StaticAlwaysOnDiscovery` datasource is designed to _always_ run, but only discover instances if a configuration property is overridden to `true`.

### The Hack

Unfortunately, there is a hack involved.  Stop reading here if you don't care about SCOM internals - the hack is supported and has no performance implications, it just looks a bit weird.

The problem we ran into during development is that when the `ExpressionFilter` in the `FilteredClassSnapshotDataMapper` runs, if the previous module called `PostOutputDataItem` and the expression does not match, the DataItem is dropped and the entire workflow terminates.  Essentially, we are back to square one.

However, if the previous module called `PostOutputDataItems` then the output is evaluated as a logical set, and if nothing matches an _empty_ collection is returned and the workflow continues.  The `ClassSnapshotDataMapper` then creates an empty discovery data item, and undiscovery occurs as expected.

I had a look to see if I could find a condition detection module or pass through probe that would have the same effect (expand a single item emitted by the scheduler into a set), but had no luck. In the end, rather than falling back on a script module I used the Registry probe to look up HKLM\Software as this will be supported on every client (for Agentless/XPlat systems, it will run on the MS, but the data found is irrelevant and ignored) and crucially has basically no performance cost as it's implemented directly in native code.

### Testing

Once imported this will immediately resolve issue number 1 above, once the agents load the new configuration.  In order to resolve issue 2 and 3, EAs will need to have their watcher discovery module swapped out, the enabling override changed from a property override to a configuration override targeting the `DiscoverInstance` setting, and finally the discovery enabled for all watcher nodes.

While this can be done manually in MP XML, a Squared Up product change will enable the new discovery workflow.  Any old EAs can be loaded in the old format (due to the old module still existing in the MP), but will be saved using the new workflow.