### PR TITLE
SU-7475 - access object properties from hosting objects rather than…

### DIFF
--- a/ManagementPacks/SquaredUp.EAM.Library/Modules/Scripts/SquaredUp.EAM.Discovery.ps1
+++ b/ManagementPacks/SquaredUp.EAM.Library/Modules/Scripts/SquaredUp.EAM.Discovery.ps1
@@ -38,6 +38,13 @@ $SCRIPT:momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script is starting. `n 
 $discoveryData = $SCRIPT:momapi.CreateDiscoveryData(0, $sourceId, $managedEntityId)
 $discoveries = $DiscoveriesJson | ConvertFrom-Json
 $objInstancesByInstanceId = @{}
+
+# Check SDK connectivity by logging the names of management servers
+#=================================================================================
+$msClsId = "9189a49e-b2de-cab0-2e4f-4925b68e335d"
+$msInsts = Get-SCOMClassInstance -Class (Get-SCOMClass -Id $msClsId)
+$SCRIPT:momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Management Server pool: [`"$([string]::Join('", "', @($msInsts | %{ $_.DisplayName })))`"]")
+
 #=================================================================================
 
 # Functions

--- a/ManagementPacks/SquaredUp.EAM.Library/Modules/Scripts/SquaredUp.EAM.Discovery.ps1
+++ b/ManagementPacks/SquaredUp.EAM.Library/Modules/Scripts/SquaredUp.EAM.Discovery.ps1
@@ -91,7 +91,7 @@ function Get-ScomHostingParentInfo {
 
 		# If so, we can return information about our host to the caller
         if ($isHosting) {
-            $parent = $relInst.SourceObject
+            $parent = Get-ScomClassInstance -Id $relInst.SourceObject.Id
             $result = @{ ParentObj = $parent; RelInst = $relInst }
             break
         }
@@ -145,7 +145,7 @@ function CreateClassInstanceFromId {
             $keyProps = $instCl.GetKeyProperties()
             foreach ($keyProp in $keyProps) {
                 $propName = "[$($instCl.Name)].$($keyProp.Name)"
-                $propRawValue = $obj."$propName".Value
+                $propRawValue = $inst."$propName".Value
                 if ($keyProp.SystemType.FullName -eq "System.Guid") {
                     # SCOM requires specific string syntax for GUIDs
                     $propValue = $propRawValue.ToString("b")
@@ -255,3 +255,4 @@ $SCRIPT:momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed after 
 # Return discovery data
 $discoveryData
 #=================================================================================
+


### PR DESCRIPTION
…assume that the SCOM PoSH SDK has correctly replicated to all hosted children.

The `CreateClassInstanceFromId` routine assumed that all key properties from all superclasses and all hosting parents were available from the instance of the object being added. Indeed, this is normally the case.

Sadly, in the case of some classes, not all properties are available like this (e.g. the property `[Microsoft.SystemCenter.ApplicationMonitoring.Net.ApplicationComponentGroup].Id` on class `Microsoft.SystemCenter.ApplicationMonitoring.Net.IIS.2008.WCFWebServiceComponent`) - in fact, the PowerShell 'NoteProperty' *is* present, but instead of the correct Guid value, null is returned!

This change alters the EA PoSH discovery script to load each hosting parent object and access any properties from classes of the hosting parent from that freshly loaded object.

(Also include a "canary" usage of the SCOM PoSH SDK at the start of the script - logging the names of the management server in this case - this will help support determine if any failures are due to problems connecting to the SDK).