### PR TITLE
SU-8024 Event logs now have eaId and eaDisplayName

### DIFF
--- a/ManagementPacks/SquaredUp.EAM.Library/Modules/Scripts/SquaredUp.EAM.Discovery.ps1
+++ b/ManagementPacks/SquaredUp.EAM.Library/Modules/Scripts/SquaredUp.EAM.Discovery.ps1
@@ -29,6 +29,29 @@ $EventID = "8011"
 $ErrorEventID = "8012"
 #=================================================================================
 
+# Logging
+#=================================================================================
+function Write-ErrorLog {
+    param (
+        $message
+    )
+
+	$SCRIPT:momapi.LogScriptEvent($ScriptName,$ErrorEventID,1,"eaId='$eaId' '$eaDisplayName' `n $message")
+	'Write-ErrorLog called: $ScriptName={0}, $ErrorEventID]{1}, $eaId={2}, $eaDisplayName={3}, $message="{4}"' -f $ScriptName, $ErrorEventID, $eaId, $eaDisplayName, $message
+}
+
+function Write-InfoLog{
+	param(
+		$message
+	)
+
+	$SCRIPT:momapi.LogScriptEvent($ScriptName, $EventID, 0, "eaId='$eaId' '$eaDisplayName' `n  $message")
+	#'Write-InfoLog called: $ScriptName={0}, $EventID]{1}, $eaId={2}, $eaDisplayName={3}, $message="{4}"' -f $ScriptName, $EventID, $eaId, $eaDisplayName, $message
+
+
+}
+#=================================================================================
+
 # Start
 #=================================================================================
 $start = [DateTime]::UtcNow
@@ -39,26 +62,33 @@ $discoveryData = $SCRIPT:momapi.CreateDiscoveryData(0, $sourceId, $managedEntity
 $discoveries = $DiscoveriesJson | ConvertFrom-Json
 $objInstancesByInstanceId = @{}
 
+# Get name of the EA we are running against
+#=================================================================================
+$eaId = "unknown"
+$eaDisplayName = "unknown"
+try {
+	$map = $discoveries.NewObjects | Where-Object {$_.TypeId -match "\[Name='EA_[0-9a-f]{32}_Availability'\]"}
+	$app = $map.properties | Where-Object {$_.propertyId -match "\[Name='SquaredUpEAMLibrary!SquaredUp.EAM.Library.Class.Availability'\]/ApplicationId"}
+	$eaId = $app.value
+	$EA = Get-SCOMClassInstance -id $eaId
+	$eaDisplayName = $EA.DisplayName
+
+}
+catch {
+	Write-ErrorLog "EA class instance not found, error thrown '$_'"
+}
+
+
 # Check SDK connectivity by logging the names of management servers
 #=================================================================================
 $msClsId = "9189a49e-b2de-cab0-2e4f-4925b68e335d"
 $msInsts = Get-SCOMClassInstance -Class (Get-SCOMClass -Id $msClsId)
-$SCRIPT:momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Management Server pool: [`"$([string]::Join('", "', @($msInsts | %{ $_.DisplayName })))`"]")
+Write-InfoLog "Management Server pool: [`"$([string]::Join('", "', @($msInsts | %{ $_.DisplayName })))`"]"
 
 #=================================================================================
 
 # Functions
 #=================================================================================
-
-function Write-ErrorLog {
-    param (
-        $message
-    )
-
-	$SCRIPT:momapi.LogScriptEvent($ScriptName,$ErrorEventID,1,$message)
-	'Write-ErrorLog called: $ScriptName={0}, $ErrorEventID]{1}, $message="{2}"' -f $ScriptName,$ErrorEventID,$message
-}
-
 #
 # Get one level of SCOM hosting information for a SCOM object
 #
@@ -242,10 +272,10 @@ try {
 			$discoveryData.AddInstance($relInstance)
 		} else {
 			if (-not $objInstancesByInstanceId.ContainsKey($discoveryRelationship.SourceInstanceId)) {
-				$SCRIPT:momapi.LogScriptEvent($ScriptName,$ErrorEventID,1,"Relationship missing source '$($discoveryRelationship.SourceInstanceId)'")
+				Write-ErrorLog "Relationship missing source '$($discoveryRelationship.SourceInstanceId)'"
 			}
 			if (-not $objInstancesByInstanceId.ContainsKey($discoveryRelationship.TargetInstanceId)) {
-				$SCRIPT:momapi.LogScriptEvent($ScriptName,$ErrorEventID,1,"Relationship missing target '$($discoveryRelationship.TargetInstanceId)'")
+				Write-ErrorLog "Relationship missing target '$($discoveryRelationship.TargetInstanceId)'"
 			}
 		}
 	}
@@ -257,7 +287,7 @@ try {
 #=================================================================================
 # Log an event for script ending and total execution time.
 $end = [DateTime]::UtcNow
-$SCRIPT:momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed after $($end - $start)")
+Write-InfoLog "Script Completed after $($end - $start)"
 
 # Return discovery data
 $discoveryData

--- a/ManagementPacks/SquaredUp.EAM.Library/Modules/Scripts/SquaredUp.EAM.Discovery.ps1
+++ b/ManagementPacks/SquaredUp.EAM.Library/Modules/Scripts/SquaredUp.EAM.Discovery.ps1
@@ -67,10 +67,7 @@ $objInstancesByInstanceId = @{}
 $eaId = "unknown"
 $eaDisplayName = "unknown"
 try {
-	$map = $discoveries.NewObjects | Where-Object {$_.TypeId -match "\[Name='EA_[0-9a-f]{32}_Availability'\]"}
-	$app = $map.properties | Where-Object {$_.propertyId -match "\[Name='SquaredUpEAMLibrary!SquaredUp.EAM.Library.Class.Availability'\]/ApplicationId"}
-	$eaId = $app.value
-	$EA = Get-SCOMClassInstance -id $eaId
+	$EA = Get-SCOMClassInstance -id $managedEntityId
 	$eaDisplayName = $EA.DisplayName
 
 }
@@ -83,7 +80,8 @@ catch {
 #=================================================================================
 $msClsId = "9189a49e-b2de-cab0-2e4f-4925b68e335d"
 $msInsts = Get-SCOMClassInstance -Class (Get-SCOMClass -Id $msClsId)
-Write-InfoLog "Management Server pool: [`"$([string]::Join('", "', @($msInsts | %{ $_.DisplayName })))`"]"
+$msInstsNames = $msInsts | %{ $_.DisplayName }
+Write-InfoLog "Management Server pool: [`"$([string]::Join('", "', @($msInstsNames)))`"]"
 
 #=================================================================================
 


### PR DESCRIPTION
When EA discovery is now run the events are now logged with the eaId and the eaDisplayName. These can be viewed in the event log. Main changes include: 
- Adding code to the `Start` section of the script to read the name and id from SCOM.
- Creating a logging section.
- Adding a function to log the information rather than calling `$SCRIPT:momapi.LogScriptEvent ` every time.
- Moving the Error log function into the logging section.

![image](https://user-images.githubusercontent.com/58977186/71260991-24bf2680-2334-11ea-8cb9-c5318d9dae20.png)
