### PR TITLE
SQ-2825: Include new Samples MP into project.

### DIFF
--- a/ManagementPacks/SquaredUp.EAM.Library.sln
+++ b/ManagementPacks/SquaredUp.EAM.Library.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2016
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{D4B43EB3-688B-4EEE-86BD-088F0B28ABB3}") = "SquaredUp.EAM.Library", "SquaredUp.EAM.Library\SquaredUp.EAM.Library.mpproj", "{196967A7-DA6A-4983-A3EB-3390AD065A31}"
 EndProject
 Project("{D4B43EB3-688B-4EEE-86BD-088F0B28ABB3}") = "SquaredUp.EAM.Custom", "SquaredUp.EAM.Custom\SquaredUp.EAM.Custom.mpproj", "{6A8ED346-433D-4793-8C87-BA9FCF8D7FD2}"
+EndProject
+Project("{D4B43EB3-688B-4EEE-86BD-088F0B28ABB3}") = "SquaredUp.EAM.Samples", "SquaredUp.EAM.Samples\SquaredUp.EAM.Samples.mpproj", "{BDF8DB8D-9FF6-42A2-8949-CE05796EDE38}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{6A8ED346-433D-4793-8C87-BA9FCF8D7FD2}.Debug|x86.Build.0 = Debug|x86
 		{6A8ED346-433D-4793-8C87-BA9FCF8D7FD2}.Release|x86.ActiveCfg = Release|x86
 		{6A8ED346-433D-4793-8C87-BA9FCF8D7FD2}.Release|x86.Build.0 = Release|x86
+		{BDF8DB8D-9FF6-42A2-8949-CE05796EDE38}.Debug|x86.ActiveCfg = Debug|x86
+		{BDF8DB8D-9FF6-42A2-8949-CE05796EDE38}.Debug|x86.Build.0 = Debug|x86
+		{BDF8DB8D-9FF6-42A2-8949-CE05796EDE38}.Release|x86.ActiveCfg = Release|x86
+		{BDF8DB8D-9FF6-42A2-8949-CE05796EDE38}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ManagementPacks/SquaredUp.EAM.Samples/FakeClasses/AvailabilityWatcherGroup.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/FakeClasses/AvailabilityWatcherGroup.mpx
@@ -1,0 +1,73 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <TypeDefinitions>
+    <EntityTypes>
+      <ClassTypes>
+
+        <ClassType ID="SquaredUp.EAM.Samples.EAM_Default" Accessibility="Public" Base="MSIL!Microsoft.SystemCenter.InstanceGroup" Abstract="false" Hosted="false" Singleton="true">
+
+        </ClassType>
+
+      </ClassTypes>
+    </EntityTypes>
+  </TypeDefinitions>
+
+  <Monitoring>
+
+    <Discoveries>
+
+      <Discovery ID="SquaredUp.EAM.Samples.Discovery.EAM_Default.Populator" Enabled="true" Target="SquaredUp.EAM.Samples.EAM_Default" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryRelationship TypeID="MSIL!Microsoft.SystemCenter.InstanceGroupContainsEntities" />
+        </DiscoveryTypes>
+        <DataSource ID="GroupPopulationDataSource" TypeID="SC!Microsoft.SystemCenter.GroupPopulator">
+          <RuleId>$MPElement$</RuleId>
+          <GroupInstanceId>$Target/Id$</GroupInstanceId>
+          <MembershipRules>
+            <MembershipRule>
+              <MonitoringClass>$MPElement[Name="Windows!Microsoft.Windows.Computer"]$</MonitoringClass>
+              <RelationshipClass>$MPElement[Name="MSIL!Microsoft.SystemCenter.InstanceGroupContainsEntities"]$</RelationshipClass>
+              <Expression>
+                <Contains>
+                  <MonitoringClass>$MPElement[Name="SC!Microsoft.SystemCenter.RootManagementServer"]$</MonitoringClass>
+                </Contains>
+              </Expression>
+            </MembershipRule>
+          </MembershipRules>
+        </DataSource>
+      </Discovery>
+
+    </Discoveries>
+
+  </Monitoring>
+
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <!-- The name of the group that will appear to users in the console. -->
+        <DisplayString ElementID="SquaredUp.EAM.Samples.EAM_Default">
+          <Name>EAM_Samples availability test clients</Name>
+          <Description>The systems that should perform availability tests against sample Enterprise Applications.</Description>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Discovery.EAM_Default.Populator">
+          <Name>Discover EAM_Samples availability test clients members</Name>
+          <Description>This discovery rule populates the group 'EAM_Samples availability test clients'</Description>
+        </DisplayString>
+      </DisplayStrings>
+      <KnowledgeArticles>
+
+        <KnowledgeArticle ElementID="SquaredUp.EAM.Samples.Discovery.EAM_Default.Populator" Visible="true">
+          <MamlContent>
+            <maml:section xmlns:maml="http://schemas.microsoft.com/maml/2004/10">
+              <maml:title>Summary</maml:title>
+              <maml:para>Discovers test clients to use as watcher nodes for EAM sample applications.</maml:para>
+            </maml:section>
+          </MamlContent>
+        </KnowledgeArticle>
+
+      </KnowledgeArticles>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/FakeClasses/Monitoring.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/FakeClasses/Monitoring.mpx
@@ -1,0 +1,143 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Rules>
+
+      <Rule ID="SquaredUp.EAM.Samples.Rule.PerfCollection.SampleComputer.Connections" Target="SquaredUp.EAM.Samples.Class.SampleComputer" Enabled="true" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
+        <Category>PerformanceCollection</Category>
+        <DataSources>
+          <DataSource ID="DS" TypeID="SquaredUp.EAM.Samples.DataSource.FakeComputerData">
+            <Name>$Target/Property[Type='System!System.Entity']/DisplayName$</Name>
+            <IntervalSeconds>900</IntervalSeconds>
+          </DataSource>
+        </DataSources>
+        <ConditionDetection ID="CD" TypeID="Perf!System.Performance.DataGenericMapper">
+          <ObjectName>Web Service</ObjectName>
+          <CounterName>Current Connections</CounterName>
+          <InstanceName />
+          <Value>$Data/Property[@Name='Connections']$</Value>
+        </ConditionDetection>
+        <WriteActions>
+          <WriteAction ID="CollectToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />
+        </WriteActions>
+      </Rule>
+
+      <Rule ID="SquaredUp.EAM.Samples.Rule.PerfCollection.SampleComputer.CPUPercent" Target="SquaredUp.EAM.Samples.Class.SampleComputer" Enabled="true" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
+        <Category>PerformanceCollection</Category>
+        <DataSources>
+          <DataSource ID="DS" TypeID="SquaredUp.EAM.Samples.DataSource.FakeComputerData">
+            <Name>$Target/Property[Type='System!System.Entity']/DisplayName$</Name>
+            <IntervalSeconds>900</IntervalSeconds>
+          </DataSource>
+        </DataSources>
+        <ConditionDetection ID="CD" TypeID="Perf!System.Performance.DataGenericMapper">
+          <ObjectName>Processor Information</ObjectName>
+          <CounterName>% Processor Time</CounterName>
+          <InstanceName />
+          <Value>$Data/Property[@Name='CPU']$</Value>
+        </ConditionDetection>
+        <WriteActions>
+          <WriteAction ID="CollectToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />
+        </WriteActions>
+      </Rule>
+
+      <Rule ID="SquaredUp.EAM.Samples.Rule.PerfCollection.SampleComputer.Memory" Target="SquaredUp.EAM.Samples.Class.SampleComputer" Enabled="true" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
+        <Category>PerformanceCollection</Category>
+        <DataSources>
+          <DataSource ID="DS" TypeID="SquaredUp.EAM.Samples.DataSource.FakeComputerData">
+            <Name>$Target/Property[Type='System!System.Entity']/DisplayName$</Name>
+            <IntervalSeconds>900</IntervalSeconds>
+          </DataSource>
+        </DataSources>
+        <ConditionDetection ID="CD" TypeID="Perf!System.Performance.DataGenericMapper">
+          <ObjectName>Memory</ObjectName>
+          <CounterName>PercentMemoryUsed</CounterName>
+          <InstanceName />
+          <Value>$Data/Property[@Name='Memory']$</Value>
+        </ConditionDetection>
+        <WriteActions>
+          <WriteAction ID="CollectToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />
+        </WriteActions>
+      </Rule>
+
+    </Rules>
+    <Monitors>
+
+      <UnitMonitor ID="SquaredUp.EAM.Samples.Monitor.SampleCloudService.Health" Accessibility="Public" Enabled="true" Target="SquaredUp.EAM.Samples.Class.SampleCloudService" ParentMonitorID="SystemHealthLibrary!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="SquaredUp.EAM.Samples.UnitMonitorType.SampleComputerAvailability" ConfirmDelivery="false">
+        <Category>AvailabilityHealth</Category>
+        <OperationalStates>
+          <OperationalState ID="Healthy" MonitorTypeStateID="Healthy" HealthState="Success" />
+          <OperationalState ID="Unhealthy" MonitorTypeStateID="Unhealthy" HealthState="Error" />
+        </OperationalStates>
+        <Configuration>
+          <Name>$Target/Property[Type='System!System.Entity']/DisplayName$</Name>
+          <IntervalSeconds>900</IntervalSeconds>
+        </Configuration>
+      </UnitMonitor>
+
+      <UnitMonitor ID="SquaredUp.EAM.Samples.Monitor.SampleComputer.Health" Accessibility="Public" Enabled="true" Target="SquaredUp.EAM.Samples.Class.SampleComputer" ParentMonitorID="SystemHealthLibrary!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="SquaredUp.EAM.Samples.UnitMonitorType.SampleComputerAvailability" ConfirmDelivery="false">
+        <Category>AvailabilityHealth</Category>
+        <OperationalStates>
+          <OperationalState ID="Healthy" MonitorTypeStateID="Healthy" HealthState="Success" />
+          <OperationalState ID="Unhealthy" MonitorTypeStateID="Unhealthy" HealthState="Error" />
+        </OperationalStates>
+        <Configuration>
+          <Name>$Target/Property[Type='System!System.Entity']/DisplayName$</Name>
+          <IntervalSeconds>900</IntervalSeconds>
+        </Configuration>
+      </UnitMonitor>
+
+    </Monitors>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.SampleCloudService.Health">
+          <Name>Sample Cloud Service Availability</Name>
+          <Description>Simple monitor to report health state for sample cloud services.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.SampleCloudService.Health" SubElementID="Healthy">
+          <Name>Healthy</Name>
+          <Description>Healthy</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.SampleCloudService.Health" SubElementID="Unhealthy">
+          <Name>Unhealthy</Name>
+          <Description>Unhealthy</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Rule.PerfCollection.SampleComputer.Connections">
+          <Name>Collect number of Connections</Name>
+          <Description>Collects connection information</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Rule.PerfCollection.SampleComputer.CPUPercent">
+          <Name>Collect CPU Processor Percent</Name>
+          <Description>Collects CPU usage information</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Rule.PerfCollection.SampleComputer.Memory">
+          <Name>Collect Memory usage percent</Name>
+          <Description>Collects memory usage information</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.SampleComputer.Health">
+          <Name>Sample Computer Availability</Name>
+          <Description>Simple monitor to report health state for sample computers.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.SampleComputer.Health" SubElementID="Healthy">
+          <Name>Healthy</Name>
+          <Description>Healthy</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.SampleComputer.Health" SubElementID="Unhealthy">
+          <Name>Unhealthy</Name>
+          <Description>Unhealthy</Description>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/FakeClasses/SampleComputer.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/FakeClasses/SampleComputer.mpx
@@ -1,0 +1,23 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <EntityTypes>
+      <ClassTypes>
+        
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleComputer" Base="System!System.Entity" Accessibility="Public" Abstract="true" Hosted="false" Singleton="false" />
+      
+      </ClassTypes>
+    </EntityTypes>
+  </TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleComputer">
+          <Name>SquaredUp EAM Sample computer</Name>
+          <Description>A sample object used to represent computers within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/FakeClasses/SampleDependency.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/FakeClasses/SampleDependency.mpx
@@ -1,0 +1,23 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <EntityTypes>
+      <ClassTypes>
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleCloudService" Base="System!System.Entity" Accessibility="Public" Abstract="true" Hosted="false" Singleton="false" />
+
+      </ClassTypes>
+    </EntityTypes>
+  </TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleCloudService">
+          <Name>SquaredUp EAM Sample Cloud Service</Name>
+          <Description>A sample object used to represent external dependencies to sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/ManagementPack.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/ManagementPack.mpx
@@ -1,0 +1,25 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+
+      <DisplayStrings>
+        <DisplayString ElementID="SquaredUp.EAM.Samples">
+          <Name>Squared Up Enterprise Application Monitoring Samples</Name>
+          <Description>Provides sample applications to demonstrate Squared Up Enterprise Application Monitoring (EAM) functionality.</Description>
+        </DisplayString>
+      </DisplayStrings>
+
+      <KnowledgeArticles>
+        <KnowledgeArticle ElementID="SquaredUp.EAM.Samples" Visible="true">
+          <MamlContent>
+            <maml:section xmlns:maml="http://schemas.microsoft.com/maml/2004/10">
+              <maml:title>Summary</maml:title>
+              <maml:para>Provides sample applications to demonstrate Squared Up Enterprise Application Monitoring (EAM) functionality.</maml:para>
+            </maml:section>
+          </MamlContent>
+        </KnowledgeArticle>
+      </KnowledgeArticles>
+
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/Moduiles/FakeDataSource.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/Moduiles/FakeDataSource.mpx
@@ -56,7 +56,7 @@
 
         <DisplayString ElementID="SquaredUp.EAM.Samples.DataSource.FakeComputerData">
           <Name>SquaredUp Sample EA fake computer data source</Name>
-          <Description>Produces fake data for health ahd performance collection</Description>
+          <Description>Produces fake data for health and performance collection</Description>
         </DisplayString>
 
         <DisplayString ElementID="SquaredUp.EAM.Samples.DataSource.FakeComputerData" SubElementID="IntervalSeconds">

--- a/ManagementPacks/SquaredUp.EAM.Samples/Moduiles/FakeDataSource.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/Moduiles/FakeDataSource.mpx
@@ -1,0 +1,70 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<TypeDefinitions>
+  <ModuleTypes>
+    <DataSourceModuleType ID="SquaredUp.EAM.Samples.DataSource.FakeComputerData" Accessibility="Public" Batching="false">
+      <Configuration>
+        <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+        <xsd:element name="IntervalSeconds" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+      </Configuration>
+      <OverrideableParameters>
+          <OverrideableParameter ID="IntervalSeconds" ParameterType="int" Selector="$Config/IntervalSeconds$"/>
+      </OverrideableParameters>
+      <ModuleImplementation>
+        <Composite>
+          <MemberModules>
+            <DataSource ID="DS" TypeID="System!System.SimpleScheduler">
+              <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
+              <SyncTime/>
+            </DataSource>
+            <ProbeAction ID="Probe" TypeID="Windows!Microsoft.Windows.PowerShellPropertyBagProbe">
+              <ScriptName>FakeComputerData.ps1</ScriptName>
+              <ScriptBody>$IncludeFileContent/Scripts/FakeComputerData.ps1$</ScriptBody>
+              <TimeoutSeconds>300</TimeoutSeconds>
+            </ProbeAction>
+
+            <ConditionDetection ID="CD" TypeID="System!System.ExpressionFilter">
+              <Expression>
+                <SimpleExpression>
+                  <ValueExpression>
+                    <XPathQuery Type="String">Property[@Name='Name']</XPathQuery>
+                  </ValueExpression>
+                  <Operator>Equal</Operator>
+                  <ValueExpression>
+                    <Value Type="String">$Config/Name$</Value>
+                  </ValueExpression>
+                </SimpleExpression>
+              </Expression>
+            </ConditionDetection>
+
+          </MemberModules>
+          <Composition>
+            <Node ID="CD">
+              <Node ID="Probe">
+                <Node ID="DS" />
+              </Node>
+            </Node>
+          </Composition>
+        </Composite>
+      </ModuleImplementation>
+      <OutputType>System!System.PropertyBagData</OutputType>
+    </DataSourceModuleType>
+  </ModuleTypes>
+</TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.DataSource.FakeComputerData">
+          <Name>SquaredUp Sample EA fake computer data source</Name>
+          <Description>Produces fake data for health ahd performance collection</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.DataSource.FakeComputerData" SubElementID="IntervalSeconds">
+          <Name>Interval (Seconds)</Name>
+          <Description>The number of seconds between executions.</Description>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/Moduiles/SampleComputerUnitMonitor.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/Moduiles/SampleComputerUnitMonitor.mpx
@@ -1,0 +1,93 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <MonitorTypes>
+       <UnitMonitorType ID="SquaredUp.EAM.Samples.UnitMonitorType.SampleComputerAvailability" Accessibility="Public">
+        <MonitorTypeStates>
+          <MonitorTypeState ID="Healthy"/>
+          <MonitorTypeState ID="Unhealthy"/>
+        </MonitorTypeStates>
+        <Configuration>
+          <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+          <xsd:element name="IntervalSeconds" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+        </Configuration>
+        <OverrideableParameters>
+          <OverrideableParameter ID="IntervalSeconds" ParameterType="int" Selector="$Config/IntervalSeconds$"/>
+        </OverrideableParameters>
+        <MonitorImplementation>
+          <MemberModules>
+            <DataSource ID="DS" TypeID="SquaredUp.EAM.Samples.DataSource.FakeComputerData">
+              <Name>$Config/Name$</Name>
+              <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
+            </DataSource>
+            <ConditionDetection ID="HealthyFilter" TypeID="System!System.ExpressionFilter">
+              <Expression>
+                <SimpleExpression>
+                  <ValueExpression>
+                    <XPathQuery Type="String">Property[@Name='Status']</XPathQuery>
+                  </ValueExpression>
+                  <Operator>Equal</Operator>
+                  <ValueExpression>
+                    <Value Type="String">Healthy</Value>
+                  </ValueExpression>
+                </SimpleExpression>
+              </Expression>
+            </ConditionDetection>
+            <ConditionDetection ID="UnhealthyFilter" TypeID="System!System.ExpressionFilter">
+              <Expression>
+                <SimpleExpression>
+                  <ValueExpression>
+                    <XPathQuery Type="String">Property[@Name='Status']</XPathQuery>
+                  </ValueExpression>
+                  <Operator>Equal</Operator>
+                  <ValueExpression>
+                    <Value Type="String">Unhealthy</Value>
+                  </ValueExpression>
+                </SimpleExpression>
+              </Expression>
+            </ConditionDetection>
+          </MemberModules>
+          <RegularDetections>
+            <RegularDetection MonitorTypeStateID="Healthy">
+              <Node ID="HealthyFilter">
+                <Node ID="DS" />
+              </Node>
+            </RegularDetection>
+            <RegularDetection MonitorTypeStateID="Unhealthy">
+              <Node ID="UnhealthyFilter">
+                <Node ID="DS" />
+              </Node>
+            </RegularDetection>
+          </RegularDetections>
+        </MonitorImplementation>
+      </UnitMonitorType>
+    </MonitorTypes>
+  </TypeDefinitions>
+  
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.UnitMonitorType.SampleComputerAvailability">
+          <Name>SquaredUp EAM Samples sample computer unit monitor type</Name>
+          <Description>Produces health data for the availability state of sample computers.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.UnitMonitorType.SampleComputerAvailability" SubElementID="Healthy">
+          <Name>Healthy</Name>
+          <Description>Sample computer is healthy</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.UnitMonitorType.SampleComputerAvailability" SubElementID="Unhealthy">
+          <Name>Unhealthy</Name>
+          <Description>Sample computer is unhealthy</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.UnitMonitorType.SampleComputerAvailability" SubElementID="IntervalSeconds">
+          <Name>Interval (Seconds)</Name>
+          <Description>The number of seconds between executions.</Description>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityOnly/AvailabilityOnly.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityOnly/AvailabilityOnly.mpx
@@ -1,0 +1,45 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <EntityTypes>
+      <ClassTypes>
+
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityOnly" Base="EAM!SquaredUp.EAM.Library.Class.EnterpriseApplication.v1" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Availability" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Availability" Hosted="false" Singleton="false" Extension="false" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Map" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Map" Hosted="false" Singleton="false" Extension="false" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Dependencies" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Dependencies" Hosted="false" Singleton="false" Extension="false" />
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.AvailabilityMonitoringGroup" Accessibility="Public" Abstract="false" Base="MSIL!Microsoft.SystemCenter.InstanceGroup" Hosted="false" Singleton="true" Extension="false" />
+
+      </ClassTypes>
+
+    </EntityTypes>
+  </TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityOnly">
+          <Name>Sample - Tailspin Toys</Name>
+          <Description>Enterprise Application 'Sample - Tailspin Toys'</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Availability">
+          <Name>Sample - Tailspin Toys Availability</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Map">
+          <Name>Sample - Tailspin Toys Map</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Dependencies">
+          <Name>Sample - Tailspin Toys Dependencies</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.AvailabilityMonitoringGroup">
+          <Name>'Sample - Tailspin Toys' Availability Monitors</Name>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityOnly/Discovery.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityOnly/Discovery.mpx
@@ -189,7 +189,7 @@
       <DisplayStrings>
 
         <DisplayString ElementID="SquaredUp.EAM.Samples.Discovery.AvailabilityOnly.AvailabilityMonitoringGroupContainsWatchers">
-          <Name>Discovers 'Sample - Tailspin Toys' Enterprise Application Availablity Monitoring Test instances</Name>
+          <Name>Discovers 'Sample - Tailspin Toys' Enterprise Application Availability Monitoring Test instances</Name>
         </DisplayString>
 
         <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Watcher.Discovery">

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityOnly/Discovery.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityOnly/Discovery.mpx
@@ -1,0 +1,205 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Discoveries>
+
+      <Discovery ID="SquaredUp.EAM.Samples.Discovery.AvailabilityOnly.AvailabilityMonitoringGroupContainsWatchers" Enabled="true" Target="SquaredUp.EAM.Samples.Class.AvailabilityOnly.AvailabilityMonitoringGroup" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes />
+        <DataSource ID="DS" TypeID="SC!Microsoft.SystemCenter.GroupPopulator">
+          <RuleId>$MPElement$</RuleId>
+          <GroupInstanceId>$Target/Id$</GroupInstanceId>
+          <MembershipRules>
+            <MembershipRule>
+              <MonitoringClass>$MPElement[Name="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher"]$</MonitoringClass>
+              <RelationshipClass>$MPElement[Name="MSIL!Microsoft.SystemCenter.InstanceGroupContainsEntities"]$</RelationshipClass>
+              <Expression>
+                <SimpleExpression>
+                  <ValueExpression>
+                    <Property>$MPElement[Name="System!System.Entity"]/DisplayName$</Property>
+                  </ValueExpression>
+                  <Operator>Equal</Operator>
+                  <ValueExpression>
+                    <Value>Sample - Tailspin Toys</Value>
+                  </ValueExpression>
+                </SimpleExpression>
+              </Expression>
+            </MembershipRule>
+          </MembershipRules>
+        </DataSource>
+      </Discovery>
+      <Discovery ID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Watcher.Discovery" Enabled="true" Target="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.MonitoringNode" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryClass TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher.Web">
+            <Property TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher" PropertyID="ConfigurationJson" />
+            <Property TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher" PropertyID="ApplicationName" />
+            <Property TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher" PropertyID="ResponseTimeThreshold" />
+          </DiscoveryClass>
+        </DiscoveryTypes>
+        <DataSource ID="DS" TypeID="EAM!SquaredUp.EAM.Library.DataSource.AvailabilityMonitoring.StaticAlwaysOnDiscovery">
+          <IntervalSeconds>86400</IntervalSeconds>
+          <DiscoverInstance>false</DiscoverInstance>
+          <ComputerName>$Target/Host/Property[Type='Windows!Microsoft.Windows.Computer']/PrincipalName$</ComputerName>
+          <ClassId>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher.Web']$</ClassId>
+          <InstanceSettings>
+            <Settings>
+              <Setting>
+                <Name>$MPElement[Name="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Name>
+                <Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='System!System.Entity']/DisplayName$</Name>
+                <Value>Sample - Tailspin Toys</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher']/ConfigurationJson$</Name>
+                <Value>{"url":"https://tailspintoys.com","match":"Tailspin","notmatch":"404"}</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher']/ApplicationName$</Name>
+                <Value>Sample - Tailspin Toys</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher']/ResponseTimeThreshold$</Name>
+                <Value>1000</Value>
+              </Setting>
+            </Settings>
+          </InstanceSettings>
+        </DataSource>
+      </Discovery>
+
+      <Discovery ID="LocalDiscovery_EA_428a274861615959af52b2b6e565660e" Enabled="true" Target="SquaredUp.EAM.Samples.Class.AvailabilityOnly" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Availability" />
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Map" />
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Dependencies" />
+        </DiscoveryTypes>
+        <DataSource ID="DS" TypeID="EAM!SquaredUp.EAM.Library.Datasource.DiscoveryProvider">
+          <DiscoveriesJson>
+{
+    "newObjects": [
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.AvailabilityOnly.Availability']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Availability']/ApplicationId$",
+                    "value": "428a2748-6161-5959-af52-b2b6e565660e"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - Tailspin Toys Availability"
+                }
+            ],
+            "instanceId": "inst_2",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.AvailabilityOnly.Map']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/ApplicationId$",
+                    "value": "428a2748-6161-5959-af52-b2b6e565660e"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - Tailspin Toys Map"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/CreateServiceMonitors$",
+                    "value": "True"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/CreateTcpMonitors$",
+                    "value": "True"
+                }
+            ],
+            "instanceId": "inst_3",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.AvailabilityOnly.Dependencies']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Dependencies']/ApplicationId$",
+                    "value": "428a2748-6161-5959-af52-b2b6e565660e"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - Tailspin Toys Dependencies"
+                }
+            ],
+            "instanceId": "inst_4",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        }
+    ],
+    "existingObjects": [
+        {
+            "objId": "428a2748-6161-5959-af52-b2b6e565660e",
+            "instanceId": "inst_1",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "objId": "a361ac41-5ccb-1d07-6092-b3bba560cc8d",
+            "instanceId": "inst_5",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        }
+    ],
+    "relationships": [
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsAvailability']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_2",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsMap']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_3",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsDependencies']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_4",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.Availability.ContainsEntity']$",
+            "sourceInstanceId": "inst_2",
+            "targetInstanceId": "inst_5",
+            "properties": null
+        }
+    ]
+}
+          </DiscoveriesJson>
+          <IntervalSeconds>86400</IntervalSeconds>
+        </DataSource>
+      </Discovery>
+
+    </Discoveries>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Discovery.AvailabilityOnly.AvailabilityMonitoringGroupContainsWatchers">
+          <Name>Discovers 'Sample - Tailspin Toys' Enterprise Application Availablity Monitoring Test instances</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Watcher.Discovery">
+          <Name>Discovers 'Sample - Tailspin Toys' Enterprise Application Availability Monitoring Test (Web)</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="LocalDiscovery_EA_428a274861615959af52b2b6e565660e">
+          <Name>Discovery to populate 'Sample - Tailspin Toys' Enterprise Application with contained monitoring objects</Name>
+        </DisplayString>
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityOnly/Monitors.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityOnly/Monitors.mpx
@@ -1,0 +1,31 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Monitors>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.AvailabilityOnly.Watcher.Group.Rollup" 
+        Accessibility="Public" 
+        Enabled="true" 
+        Target="SquaredUp.EAM.Samples.Class.AvailabilityOnly.AvailabilityMonitoringGroup" 
+        ParentMonitorID="SystemHealthLibrary!System.Health.AvailabilityState" 
+        Remotable="true" 
+        Priority="Normal" 
+        RelationshipType="MSIL!Microsoft.SystemCenter.InstanceGroupContainsEntities" 
+        MemberMonitor="SystemHealthLibrary!System.Health.AvailabilityState">
+        <Category>AvailabilityHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+    </Monitors>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+      <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.AvailabilityOnly.Watcher.Group.Rollup">
+        <Name>Availability test rollup</Name>
+      </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityOnly/Overrides.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityOnly/Overrides.mpx
@@ -43,7 +43,7 @@
           <Name>Web Availability Test Override for 'Sample - Tailspin Toys'</Name>
         </DisplayString>
         <DisplayString ElementID="SquaredUp.EAM.Samples.Override.AvailabilityOnly.Availability.PerfCollection">
-          <Name>Web Availability Test Performance collection Override for 'Sample - Tailspin Toys'</Name>
+          <Name>Web Availability Test Performance Collection Override for 'Sample - Tailspin Toys'</Name>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityOnly/Overrides.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityOnly/Overrides.mpx
@@ -16,6 +16,18 @@
         </Value>
       </MonitorConfigurationOverride>
 
+      <RuleConfigurationOverride ID="SquaredUp.EAM.Samples.Override.AvailabilityOnly.Availability.PerfCollection" 
+        Context="SquaredUp.EAM.Samples.Class.AvailabilityOnly.AvailabilityMonitoringGroup" 
+        Enforced="false" 
+        Rule="EAM!SquaredUp.EAM.Library.Rule.AvailabilityMonitoring.Web.PerformanceCollection" 
+        Module="DS" 
+        Parameter="Script">
+        <Value>
+          $result = New-Object -TypeName PSobject -Property (@{'Success'=$true;'Description'='';'ResponseTime'=[double](Get-Random -Minimum 5500 -Maximum 10000)})
+          return $result
+        </Value>
+      </RuleConfigurationOverride>
+
     </Overrides>
   </Monitoring>
   <LanguagePacks>
@@ -29,6 +41,9 @@
         </DisplayString>
         <DisplayString ElementID="SquaredUp.EAM.Samples.Override.AvailabilityOnly.Availabilty.TestScript">
           <Name>Web Availability Test Override for 'Sample - Tailspin Toys'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Override.AvailabilityOnly.Availability.PerfCollection">
+          <Name>Web Availability Test Performance collection Override for 'Sample - Tailspin Toys'</Name>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityOnly/Overrides.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityOnly/Overrides.mpx
@@ -1,0 +1,36 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Overrides>
+      <MonitorPropertyOverride ID="SquaredUp.EAM.Samples.Override.AvailabilityOnly" Context="SquaredUp.EAM.Samples.Class.AvailabilityOnly" Enforced="false" Monitor="EAM!SquaredUp.EAM.Library.Monitor.ManualAvailability" Property="Enabled">
+        <Value>true</Value>
+      </MonitorPropertyOverride>
+
+      <DiscoveryConfigurationOverride ID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Override.WatcherDiscovery" Context="SquaredUp.EAM.Samples.EAM_Default"  Enforced="false" Discovery="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Watcher.Discovery" Parameter="DiscoverInstance" Module="DS">
+        <Value>true</Value>
+      </DiscoveryConfigurationOverride>
+
+      <MonitorConfigurationOverride ID="SquaredUp.EAM.Samples.Override.AvailabilityOnly.Availabilty.TestScript" Context="SquaredUp.EAM.Samples.Class.AvailabilityOnly.AvailabilityMonitoringGroup" Enforced="false" Monitor="EAM!SquaredUp.EAM.Library.Monitor.AvailabilityMonitoring.Web" Parameter="Script">
+        <Value>
+          $result = New-Object -TypeName PSobject -Property (@{'Success'=$true;'Description'='';'ResponseTime'=[double](Get-Random -Minimum 5500 -Maximum 10000)})
+          return $result
+        </Value>
+      </MonitorConfigurationOverride>
+
+    </Overrides>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Override.AvailabilityOnly">
+          <Name>Manual Availability Override for 'Sample - Tailspin Toys'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityOnly.Override.WatcherDiscovery">
+          <Name>Watcher Discovery Override for 'Sample - Tailspin Toys'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Override.AvailabilityOnly.Availabilty.TestScript">
+          <Name>Web Availability Test Override for 'Sample - Tailspin Toys'</Name>
+        </DisplayString>
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/AvailabilityWithDependencies.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/AvailabilityWithDependencies.mpx
@@ -1,0 +1,48 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <EntityTypes>
+      <ClassTypes>
+
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies" Base="EAM!SquaredUp.EAM.Library.Class.EnterpriseApplication.v1" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Availability" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Availability" Hosted="false" Singleton="false" Extension="false" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Map" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Map" Hosted="false" Singleton="false" Extension="false" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Dependencies" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Dependencies" Hosted="false" Singleton="false" Extension="false" />
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.AvailabilityMonitoringGroup" Accessibility="Public" Abstract="false" Base="MSIL!Microsoft.SystemCenter.InstanceGroup" Hosted="false" Singleton="true" Extension="false" />
+
+      </ClassTypes>
+
+      <RelationshipTypes>
+
+      </RelationshipTypes>
+    </EntityTypes>
+  </TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies">
+          <Name>Sample - SmartHotel 360</Name>
+          <Description>Enterprise Application 'Sample - SmartHotel 360'</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Availability">
+          <Name>Sample - SmartHotel 360 Availability</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Map">
+          <Name>Sample - SmartHotel 360 Map</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Dependencies">
+          <Name>Sample - SmartHotel 360 Dependencies</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.AvailabilityMonitoringGroup">
+          <Name>'Sample - SmartHotel 360' Availability Monitors</Name>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/CloudObjects.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/CloudObjects.mpx
@@ -1,0 +1,29 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <EntityTypes>
+      <ClassTypes>
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleCloudService.SmartHotel.AzureActiveDirectory" Base="SquaredUp.EAM.Samples.Class.SampleCloudService" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleCloudService.SmartHotel.AzureCloudService" Base="SquaredUp.EAM.Samples.Class.SampleCloudService" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+
+      </ClassTypes>
+    </EntityTypes>
+  </TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleCloudService.SmartHotel.AzureActiveDirectory">
+          <Name>Azure Active Directory (SmartHotel 360)</Name>
+          <Description>A sample object used to represent a cloud dependency within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleCloudService.SmartHotel.AzureCloudService">
+          <Name>SmartHotel Azure Cloud Service</Name>
+          <Description>A sample object used to represent a cloud dependency within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/Discovery.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/Discovery.mpx
@@ -214,7 +214,7 @@
       <DisplayStrings>
 
         <DisplayString ElementID="SquaredUp.EAM.Samples.Discovery.AvailabilityWithDependencies.AvailabilityMonitoringGroupContainsWatchers">
-          <Name>Discovers 'Sample - SmartHotel 360' Enterprise Application Availablity Monitoring Test instances</Name>
+          <Name>Discovers 'Sample - SmartHotel 360' Enterprise Application Availability Monitoring Test instances</Name>
         </DisplayString>
 
         <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Watcher.Discovery">

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/Discovery.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/Discovery.mpx
@@ -1,0 +1,231 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Discoveries>
+
+      <Discovery ID="SquaredUp.EAM.Samples.Discovery.AvailabilityWithDependencies.AvailabilityMonitoringGroupContainsWatchers" Enabled="true" Target="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.AvailabilityMonitoringGroup" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes />
+        <DataSource ID="DS" TypeID="SC!Microsoft.SystemCenter.GroupPopulator">
+          <RuleId>$MPElement$</RuleId>
+          <GroupInstanceId>$Target/Id$</GroupInstanceId>
+          <MembershipRules>
+            <MembershipRule>
+              <MonitoringClass>$MPElement[Name="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher"]$</MonitoringClass>
+              <RelationshipClass>$MPElement[Name="MSIL!Microsoft.SystemCenter.InstanceGroupContainsEntities"]$</RelationshipClass>
+              <Expression>
+                <SimpleExpression>
+                  <ValueExpression>
+                    <Property>$MPElement[Name="System!System.Entity"]/DisplayName$</Property>
+                  </ValueExpression>
+                  <Operator>Equal</Operator>
+                  <ValueExpression>
+                    <Value>Sample - SmartHotel 360</Value>
+                  </ValueExpression>
+                </SimpleExpression>
+              </Expression>
+            </MembershipRule>
+          </MembershipRules>
+        </DataSource>
+      </Discovery>
+      <Discovery ID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Watcher.Discovery" Enabled="true" Target="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.MonitoringNode" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryClass TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher.Web">
+            <Property TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher" PropertyID="ConfigurationJson" />
+            <Property TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher" PropertyID="ApplicationName" />
+            <Property TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher" PropertyID="ResponseTimeThreshold" />
+          </DiscoveryClass>
+        </DiscoveryTypes>
+        <DataSource ID="DS" TypeID="EAM!SquaredUp.EAM.Library.DataSource.AvailabilityMonitoring.StaticAlwaysOnDiscovery">
+          <IntervalSeconds>86400</IntervalSeconds>
+          <DiscoverInstance>false</DiscoverInstance>
+          <ComputerName>$Target/Host/Property[Type='Windows!Microsoft.Windows.Computer']/PrincipalName$</ComputerName>
+          <ClassId>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher.Web']$</ClassId>
+          <InstanceSettings>
+            <Settings>
+              <Setting>
+                <Name>$MPElement[Name="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Name>
+                <Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='System!System.Entity']/DisplayName$</Name>
+                <Value>Sample - SmartHotel 360</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher']/ConfigurationJson$</Name>
+                <Value>{"url":"https://SmartHotel360.com","match":"","notmatch":""}</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher']/ApplicationName$</Name>
+                <Value>Sample - SmartHotel 360</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher']/ResponseTimeThreshold$</Name>
+                <Value>1000</Value>
+              </Setting>
+            </Settings>
+          </InstanceSettings>
+        </DataSource>
+      </Discovery>
+
+      <Discovery ID="LocalDiscovery_EA_d9d90b8b300865f4082b7e4a7fec2b29" Enabled="true" Target="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Availability" />
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Map" />
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Dependencies" />
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.SampleCloudService" />
+        </DiscoveryTypes>
+        <DataSource ID="DS" TypeID="EAM!SquaredUp.EAM.Library.Datasource.DiscoveryProvider">
+          <DiscoveriesJson>
+{
+    "newObjects": [
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Availability']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Availability']/ApplicationId$",
+                    "value": "d9d90b8b-3008-65f4-082b-7e4a7fec2b29"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - SmartHotel 360 Availability"
+                }
+            ],
+            "instanceId": "inst_2",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Map']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/ApplicationId$",
+                    "value": "d9d90b8b-3008-65f4-082b-7e4a7fec2b29"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - SmartHotel 360 Map"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/CreateServiceMonitors$",
+                    "value": "True"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/CreateTcpMonitors$",
+                    "value": "True"
+                }
+            ],
+            "instanceId": "inst_3",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Dependencies']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Dependencies']/ApplicationId$",
+                    "value": "d9d90b8b-3008-65f4-082b-7e4a7fec2b29"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - SmartHotel 360 Dependencies"
+                }
+            ],
+            "instanceId": "inst_4",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        }
+    ],
+    "existingObjects": [
+        {
+            "objId": "d9d90b8b-3008-65f4-082b-7e4a7fec2b29",
+            "instanceId": "inst_1",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "objId": "768fceb1-eeac-76bd-701d-b9b9c8d86b18",
+            "instanceId": "inst_6",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "objId": "c15f7f1f-9831-6a7b-dfc4-5bea6954f3f7",
+            "instanceId": "inst_7",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "objId": "8a9417a9-83ea-ad35-8169-60702cceab2f",
+            "instanceId": "inst_8",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        }
+    ],
+    "relationships": [
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsAvailability']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_2",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsMap']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_3",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsDependencies']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_4",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.Availability.ContainsEntity']$",
+            "sourceInstanceId": "inst_2",
+            "targetInstanceId": "inst_6",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.Dependencies.ContainsEntity']$",
+            "sourceInstanceId": "inst_4",
+            "targetInstanceId": "inst_7",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.Dependencies.ContainsEntity']$",
+            "sourceInstanceId": "inst_4",
+            "targetInstanceId": "inst_8",
+            "properties": null
+        }
+    ]
+}
+          </DiscoveriesJson>
+          <IntervalSeconds>86400</IntervalSeconds>
+        </DataSource>
+      </Discovery>
+
+    </Discoveries>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Discovery.AvailabilityWithDependencies.AvailabilityMonitoringGroupContainsWatchers">
+          <Name>Discovers 'Sample - SmartHotel 360' Enterprise Application Availablity Monitoring Test instances</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Watcher.Discovery">
+          <Name>Discovers 'Sample - SmartHotel 360' Enterprise Application Availability Monitoring Test (Web)</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="LocalDiscovery_EA_d9d90b8b300865f4082b7e4a7fec2b29">
+          <Name>Discovery to populate 'Sample - SmartHotel 360' Enterprise Application with contained monitoring objects</Name>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/Monitors.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/Monitors.mpx
@@ -1,0 +1,31 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Monitors>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.AvailabilityWithDependencies.Watcher.Group.Rollup" 
+        Accessibility="Public" 
+        Enabled="true" 
+        Target="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.AvailabilityMonitoringGroup" 
+        ParentMonitorID="SystemHealthLibrary!System.Health.AvailabilityState" 
+        Remotable="true" 
+        Priority="Normal" 
+        RelationshipType="MSIL!Microsoft.SystemCenter.InstanceGroupContainsEntities" 
+        MemberMonitor="SystemHealthLibrary!System.Health.AvailabilityState">
+        <Category>AvailabilityHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+    </Monitors>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+      <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.AvailabilityWithDependencies.Watcher.Group.Rollup">
+        <Name>Availability test rollup</Name>
+      </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/Overrides.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/Overrides.mpx
@@ -43,7 +43,7 @@
           <Name>Web Availability Test Override for 'Sample - SmartHotel 360'</Name>
         </DisplayString>
         <DisplayString ElementID="SquaredUp.EAM.Samples.Override.AvailabilityWithDependencies.Availability.PerfCollection">
-          <Name>Web Availability Test Performance collection Override for 'Sample - SmartHotel 360'</Name>
+          <Name>Web Availability Test Performance Collection Override for 'Sample - SmartHotel 360'</Name>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/Overrides.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/Overrides.mpx
@@ -1,0 +1,36 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Overrides>
+      <MonitorPropertyOverride ID="SquaredUp.EAM.Samples.Override.AvailabilityWithDependencies" Context="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies" Enforced="false" Monitor="EAM!SquaredUp.EAM.Library.Monitor.ManualAvailability" Property="Enabled">
+        <Value>true</Value>
+      </MonitorPropertyOverride>
+
+      <DiscoveryConfigurationOverride ID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Override.WatcherDiscovery" Context="SquaredUp.EAM.Samples.EAM_Default"  Enforced="false" Discovery="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Watcher.Discovery" Parameter="DiscoverInstance" Module="DS">
+        <Value>true</Value>
+      </DiscoveryConfigurationOverride>
+
+      <MonitorConfigurationOverride ID="SquaredUp.EAM.Samples.Override.AvailabilityWithDependencies.Availabilty.TestScript" Context="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.AvailabilityMonitoringGroup" Enforced="false" Monitor="EAM!SquaredUp.EAM.Library.Monitor.AvailabilityMonitoring.Web" Parameter="Script">
+        <Value>
+          $result = New-Object -TypeName PSobject -Property (@{'Success'=$true;'Description'='';'ResponseTime'=[double](Get-Random -Minimum 50 -Maximum 1000)})
+          return $result
+        </Value>
+      </MonitorConfigurationOverride>
+
+    </Overrides>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Override.AvailabilityWithDependencies">
+          <Name>Manual Availability Override for 'Sample - SmartHotel 360'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.Override.WatcherDiscovery">
+          <Name>Watcher Discovery Override for 'Sample - SmartHotel 360'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Override.AvailabilityWithDependencies.Availabilty.TestScript">
+          <Name>Web Availability Test Override for 'Sample - SmartHotel 360'</Name>
+        </DisplayString>
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/Overrides.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithDependencies/Overrides.mpx
@@ -16,6 +16,18 @@
         </Value>
       </MonitorConfigurationOverride>
 
+      <RuleConfigurationOverride ID="SquaredUp.EAM.Samples.Override.AvailabilityWithDependencies.Availability.PerfCollection"
+         Context="SquaredUp.EAM.Samples.Class.AvailabilityWithDependencies.AvailabilityMonitoringGroup"
+         Enforced="false"
+         Rule="EAM!SquaredUp.EAM.Library.Rule.AvailabilityMonitoring.Web.PerformanceCollection"
+         Module="DS"
+         Parameter="Script">
+        <Value>
+          $result = New-Object -TypeName PSobject -Property (@{'Success'=$true;'Description'='';'ResponseTime'=[double](Get-Random -Minimum 50 -Maximum 1000)})
+          return $result
+        </Value>
+      </RuleConfigurationOverride>
+
     </Overrides>
   </Monitoring>
   <LanguagePacks>
@@ -29,6 +41,9 @@
         </DisplayString>
         <DisplayString ElementID="SquaredUp.EAM.Samples.Override.AvailabilityWithDependencies.Availabilty.TestScript">
           <Name>Web Availability Test Override for 'Sample - SmartHotel 360'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Override.AvailabilityWithDependencies.Availability.PerfCollection">
+          <Name>Web Availability Test Performance collection Override for 'Sample - SmartHotel 360'</Name>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithSimpleMap/AvailabilityWithSimpleMap.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithSimpleMap/AvailabilityWithSimpleMap.mpx
@@ -1,0 +1,72 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <EntityTypes>
+      <ClassTypes>
+
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap" Base="EAM!SquaredUp.EAM.Library.Class.EnterpriseApplication.v1" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Availability" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Availability" Hosted="false" Singleton="false" Extension="false" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Map" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Map" Hosted="false" Singleton="false" Extension="false" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Dependencies" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Dependencies" Hosted="false" Singleton="false" Extension="false" />
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.AvailabilityMonitoringGroup" Accessibility="Public" Abstract="false" Base="MSIL!Microsoft.SystemCenter.InstanceGroup" Hosted="false" Singleton="true" Extension="false" />
+
+        <ClassType ID="EA_526ba86deec4115e9949a013c1f2d86e_Map_13bb286905f5449baa3ff8aa731afd18" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.MapGroup" Hosted="false" Singleton="false" Extension="false" />
+
+      </ClassTypes>
+
+      <RelationshipTypes>
+
+        <RelationshipType ID="EA_526ba86deec4115e9949a013c1f2d86e_Map_Contains_13bb286905f5449baa3ff8aa731afd18" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Relationship.Map.ContainsMapGroup">
+          <Source ID="source" MinCardinality="0" MaxCardinality="2147483647" Type="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Map" />
+          <Target ID="target" MinCardinality="0" MaxCardinality="2147483647" Type="EA_526ba86deec4115e9949a013c1f2d86e_Map_13bb286905f5449baa3ff8aa731afd18" />
+        </RelationshipType>
+        <RelationshipType ID="EA_526ba86deec4115e9949a013c1f2d86e_Map_13bb286905f5449baa3ff8aa731afd18_Contains_Entity" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Relationship.MapGroup.ContainsEntity">
+          <Source ID="source" MinCardinality="0" MaxCardinality="2147483647" Type="EA_526ba86deec4115e9949a013c1f2d86e_Map_13bb286905f5449baa3ff8aa731afd18" />
+          <Target ID="target" MinCardinality="0" MaxCardinality="2147483647" Type="System!System.Entity" />
+        </RelationshipType>
+
+      </RelationshipTypes>
+    </EntityTypes>
+  </TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap">
+          <Name>Sample - AdventureWorks OLTP</Name>
+          <Description>Enterprise Application 'Sample - AdventureWorks OLTP'</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Availability">
+          <Name>Sample - AdventureWorks OLTP Availability</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Map">
+          <Name>Sample - AdventureWorks OLTP Map</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Dependencies">
+          <Name>Sample - AdventureWorks OLTP Dependencies</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.AvailabilityMonitoringGroup">
+          <Name>'Sample - AdventureWorks OLTP' Availability Monitors</Name>
+        </DisplayString>
+
+
+        <DisplayString ElementID="EA_526ba86deec4115e9949a013c1f2d86e_Map_13bb286905f5449baa3ff8aa731afd18">
+          <Name>Servers</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="EA_526ba86deec4115e9949a013c1f2d86e_Map_Contains_13bb286905f5449baa3ff8aa731afd18">
+          <Name>Relationship in EA Sample - AdventureWorks OLTP to include group 'servers' in map.</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="EA_526ba86deec4115e9949a013c1f2d86e_Map_13bb286905f5449baa3ff8aa731afd18_Contains_Entity">
+          <Name>Relationship in EA Sample - AdventureWorks OLTP to include objects in map group 'servers'.</Name>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithSimpleMap/Computers.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithSimpleMap/Computers.mpx
@@ -1,0 +1,29 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <EntityTypes>
+      <ClassTypes>
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleComputer.AdventureWorks.Web01" Base="SquaredUp.EAM.Samples.Class.SampleComputer" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleComputer.AdventureWorks.SQL01" Base="SquaredUp.EAM.Samples.Class.SampleComputer" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+
+      </ClassTypes>
+    </EntityTypes>
+  </TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleComputer.AdventureWorks.Web01">
+          <Name>AW-WEB-01.AdventureWorks.com</Name>
+          <Description>A sample object used to represent a computer within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleComputer.AdventureWorks.SQL01">
+          <Name>AW-SQL-01.AdventureWorks.com</Name>
+          <Description>A sample object used to represent a computer within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithSimpleMap/Discovery.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithSimpleMap/Discovery.mpx
@@ -1,0 +1,267 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Discoveries>
+
+      <Discovery ID="SquaredUp.EAM.Samples.Discovery.AvailabilityWithSimpleMap.AvailabilityMonitoringGroupContainsWatchers" Enabled="true" Target="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.AvailabilityMonitoringGroup" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes />
+        <DataSource ID="DS" TypeID="SC!Microsoft.SystemCenter.GroupPopulator">
+          <RuleId>$MPElement$</RuleId>
+          <GroupInstanceId>$Target/Id$</GroupInstanceId>
+          <MembershipRules>
+            <MembershipRule>
+              <MonitoringClass>$MPElement[Name="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher"]$</MonitoringClass>
+              <RelationshipClass>$MPElement[Name="MSIL!Microsoft.SystemCenter.InstanceGroupContainsEntities"]$</RelationshipClass>
+              <Expression>
+                <SimpleExpression>
+                  <ValueExpression>
+                    <Property>$MPElement[Name="System!System.Entity"]/DisplayName$</Property>
+                  </ValueExpression>
+                  <Operator>Equal</Operator>
+                  <ValueExpression>
+                    <Value>Sample - AdventureWorks OLTP</Value>
+                  </ValueExpression>
+                </SimpleExpression>
+              </Expression>
+            </MembershipRule>
+          </MembershipRules>
+        </DataSource>
+      </Discovery>
+      
+      <Discovery ID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Watcher.Discovery" Enabled="true" Target="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.MonitoringNode" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryClass TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher.Web">
+            <Property TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher" PropertyID="ConfigurationJson" />
+            <Property TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher" PropertyID="ApplicationName" />
+            <Property TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher" PropertyID="ResponseTimeThreshold" />
+          </DiscoveryClass>
+        </DiscoveryTypes>
+        <DataSource ID="DS" TypeID="EAM!SquaredUp.EAM.Library.DataSource.AvailabilityMonitoring.StaticAlwaysOnDiscovery">
+          <IntervalSeconds>86400</IntervalSeconds>
+          <DiscoverInstance>false</DiscoverInstance>
+          <ComputerName>$Target/Host/Property[Type='Windows!Microsoft.Windows.Computer']/PrincipalName$</ComputerName>
+          <ClassId>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher.Web']$</ClassId>
+          <InstanceSettings>
+            <Settings>
+              <Setting>
+                <Name>$MPElement[Name="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Name>
+                <Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='System!System.Entity']/DisplayName$</Name>
+                <Value>Sample - AdventureWorks OLTP</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher']/ConfigurationJson$</Name>
+                <Value>{"url":"https://adventureworks.com","match":"Login","notmatch":""}</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher']/ApplicationName$</Name>
+                <Value>Sample - AdventureWorks OLTP</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher']/ResponseTimeThreshold$</Name>
+                <Value>1000</Value>
+              </Setting>
+            </Settings>
+          </InstanceSettings>
+        </DataSource>
+      </Discovery>
+
+      <Discovery ID="LocalDiscovery_EA_526ba86deec4115e9949a013c1f2d86e" Enabled="true" Target="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Availability" />
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Map" />
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Dependencies" />
+          <DiscoveryClass TypeID="EA_526ba86deec4115e9949a013c1f2d86e_Map_13bb286905f5449baa3ff8aa731afd18" />
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.SampleComputer" />
+        </DiscoveryTypes>
+        <DataSource ID="DS" TypeID="EAM!SquaredUp.EAM.Library.Datasource.DiscoveryProvider">
+          <DiscoveriesJson>
+{
+    "newObjects": [
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Availability']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Availability']/ApplicationId$",
+                    "value": "526ba86d-eec4-115e-9949-a013c1f2d86e"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - AdventureWorks OLTP Availability"
+                }
+            ],
+            "instanceId": "inst_2",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Map']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/ApplicationId$",
+                    "value": "526ba86d-eec4-115e-9949-a013c1f2d86e"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - AdventureWorks OLTP Map"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/CreateServiceMonitors$",
+                    "value": "True"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/CreateTcpMonitors$",
+                    "value": "True"
+                }
+            ],
+            "instanceId": "inst_3",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Dependencies']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Dependencies']/ApplicationId$",
+                    "value": "526ba86d-eec4-115e-9949-a013c1f2d86e"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - AdventureWorks OLTP Dependencies"
+                }
+            ],
+            "instanceId": "inst_4",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_526ba86deec4115e9949a013c1f2d86e_Map_13bb286905f5449baa3ff8aa731afd18']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/ApplicationId$",
+                    "value": "526ba86d-eec4-115e-9949-a013c1f2d86e"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/GroupId$",
+                    "value": "13bb2869-05f5-449b-aa3f-f8aa731afd18"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Servers"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/HorizIndex$",
+                    "value": "0"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/VertIndex$",
+                    "value": "0"
+                }
+            ],
+            "instanceId": "inst_5",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        }
+    ],
+    "existingObjects": [
+        {
+            "objId": "526ba86d-eec4-115e-9949-a013c1f2d86e",
+            "instanceId": "inst_1",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "objId": "42ef646c-8b4b-d3d4-9491-6b4f01b20268",
+            "instanceId": "inst_6",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "objId": "ae4c8c84-7497-6be8-b4cb-f0f263f0ac4d",
+            "instanceId": "inst_7",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "objId": "f0a4aa8e-eadb-8b69-a01e-6d2749270cb9",
+            "instanceId": "inst_8",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        }
+    ],
+    "relationships": [
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsAvailability']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_2",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsMap']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_3",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsDependencies']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_4",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.Availability.ContainsEntity']$",
+            "sourceInstanceId": "inst_2",
+            "targetInstanceId": "inst_6",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_526ba86deec4115e9949a013c1f2d86e_Map_Contains_13bb286905f5449baa3ff8aa731afd18']$",
+            "sourceInstanceId": "inst_3",
+            "targetInstanceId": "inst_5",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_526ba86deec4115e9949a013c1f2d86e_Map_13bb286905f5449baa3ff8aa731afd18_Contains_Entity']$",
+            "sourceInstanceId": "inst_5",
+            "targetInstanceId": "inst_7",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_526ba86deec4115e9949a013c1f2d86e_Map_13bb286905f5449baa3ff8aa731afd18_Contains_Entity']$",
+            "sourceInstanceId": "inst_5",
+            "targetInstanceId": "inst_8",
+            "properties": null
+        }
+    ]
+}
+          </DiscoveriesJson>
+          <IntervalSeconds>86400</IntervalSeconds>
+        </DataSource>
+      </Discovery>
+
+    </Discoveries>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Discovery.AvailabilityWithSimpleMap.AvailabilityMonitoringGroupContainsWatchers">
+          <Name>Discovers 'Sample - AdventureWorks OLTP' Enterprise Application Availablity Monitoring Test instances</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Watcher.Discovery">
+          <Name>Discovers 'Sample - AdventureWorks OLTP' Enterprise Application Availability Monitoring Test (Web)</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="LocalDiscovery_EA_526ba86deec4115e9949a013c1f2d86e">
+          <Name>Discovery to populate 'Sample - AdventureWorks OLTP' Enterprise Application with contained monitoring objects</Name>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithSimpleMap/Discovery.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithSimpleMap/Discovery.mpx
@@ -250,7 +250,7 @@
       <DisplayStrings>
 
         <DisplayString ElementID="SquaredUp.EAM.Samples.Discovery.AvailabilityWithSimpleMap.AvailabilityMonitoringGroupContainsWatchers">
-          <Name>Discovers 'Sample - AdventureWorks OLTP' Enterprise Application Availablity Monitoring Test instances</Name>
+          <Name>Discovers 'Sample - AdventureWorks OLTP' Enterprise Application Availability Monitoring Test instances</Name>
         </DisplayString>
 
         <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Watcher.Discovery">

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithSimpleMap/Monitors.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithSimpleMap/Monitors.mpx
@@ -1,0 +1,96 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Monitors>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.AvailabilityWithSimpleMap.Watcher.Group.Rollup" 
+        Accessibility="Public" 
+        Enabled="true" 
+        Target="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.AvailabilityMonitoringGroup" 
+        ParentMonitorID="SystemHealthLibrary!System.Health.AvailabilityState" 
+        Remotable="true" 
+        Priority="Normal" 
+        RelationshipType="MSIL!Microsoft.SystemCenter.InstanceGroupContainsEntities" 
+        MemberMonitor="SystemHealthLibrary!System.Health.AvailabilityState">
+        <Category>AvailabilityHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.AvailabilityWithSimpleMap.Map_AvailabilityHealth_HealthMonitor" 
+        Accessibility="Public" 
+        Enabled="true" 
+        Target="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Map" 
+        ParentMonitorID="SystemHealthLibrary!System.Health.AvailabilityState"
+        Remotable="true"
+        Priority="Normal"
+        RelationshipType="EA_526ba86deec4115e9949a013c1f2d86e_Map_Contains_13bb286905f5449baa3ff8aa731afd18"
+        MemberMonitor="SystemHealthLibrary!System.Health.AvailabilityState">
+        <Category>AvailabilityHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.AvailabilityWithSimpleMap.Map_ConfigurationHealth_HealthMonitor"
+        Accessibility="Public"
+        Enabled="true"
+        Target="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Map"
+        ParentMonitorID="SystemHealthLibrary!System.Health.ConfigurationState"
+        Remotable="true"
+        Priority="Normal"
+        RelationshipType="EA_526ba86deec4115e9949a013c1f2d86e_Map_Contains_13bb286905f5449baa3ff8aa731afd18"
+        MemberMonitor="SystemHealthLibrary!System.Health.ConfigurationState">
+        <Category>ConfigurationHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.AvailabilityWithSimpleMap.Map_PerformanceHealth_HealthMonitor"
+        Accessibility="Public"
+        Enabled="true"
+        Target="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Map"
+        ParentMonitorID="SystemHealthLibrary!System.Health.PerformanceState"
+        Remotable="true"
+        Priority="Normal"
+        RelationshipType="EA_526ba86deec4115e9949a013c1f2d86e_Map_Contains_13bb286905f5449baa3ff8aa731afd18"
+        MemberMonitor="SystemHealthLibrary!System.Health.PerformanceState">
+        <Category>PerformanceHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.AvailabilityWithSimpleMap.Map_SecurityHealth_HealthMonitor"
+        Accessibility="Public"
+        Enabled="true"
+        Target="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Map"
+        ParentMonitorID="SystemHealthLibrary!System.Health.SecurityState"
+        Remotable="true"
+        Priority="Normal"
+        RelationshipType="EA_526ba86deec4115e9949a013c1f2d86e_Map_Contains_13bb286905f5449baa3ff8aa731afd18"
+        MemberMonitor="SystemHealthLibrary!System.Health.SecurityState">
+        <Category>SecurityHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+    </Monitors>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+      <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.AvailabilityWithSimpleMap.Watcher.Group.Rollup">
+        <Name>Availability test rollup</Name>
+      </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.AvailabilityWithSimpleMap.Map_AvailabilityHealth_HealthMonitor">
+          <Name>Availability roll-up for 'Servers'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.AvailabilityWithSimpleMap.Map_ConfigurationHealth_HealthMonitor">
+          <Name>Configuration roll-up for 'Servers'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.AvailabilityWithSimpleMap.Map_PerformanceHealth_HealthMonitor">
+          <Name>Performance roll-up for 'Servers'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.AvailabilityWithSimpleMap.Map_SecurityHealth_HealthMonitor">
+          <Name>Security roll-up for 'Servers'</Name>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithSimpleMap/Overrides.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithSimpleMap/Overrides.mpx
@@ -1,0 +1,36 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Overrides>
+      <MonitorPropertyOverride ID="SquaredUp.EAM.Samples.Override.AvailabilityWithSimpleMap" Context="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap" Enforced="false" Monitor="EAM!SquaredUp.EAM.Library.Monitor.ManualAvailability" Property="Enabled">
+        <Value>true</Value>
+      </MonitorPropertyOverride>
+
+      <DiscoveryConfigurationOverride ID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Override.WatcherDiscovery" Context="SquaredUp.EAM.Samples.EAM_Default"  Enforced="false" Discovery="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Watcher.Discovery" Parameter="DiscoverInstance" Module="DS">
+        <Value>true</Value>
+      </DiscoveryConfigurationOverride>
+
+      <MonitorConfigurationOverride ID="SquaredUp.EAM.Samples.Override.AvailabilityWithSimpleMap.Availabilty.TestScript" Context="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.AvailabilityMonitoringGroup" Enforced="false" Monitor="EAM!SquaredUp.EAM.Library.Monitor.AvailabilityMonitoring.Web" Parameter="Script">
+        <Value>
+          $result = New-Object -TypeName PSobject -Property (@{'Success'=$true;'Description'='';'ResponseTime'=[double](Get-Random -Minimum 50 -Maximum 1000)})
+          return $result
+        </Value>
+      </MonitorConfigurationOverride>
+
+    </Overrides>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Override.AvailabilityWithSimpleMap">
+          <Name>Manual Availability Override for 'Sample - AdventureWorks OLTP'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.Override.WatcherDiscovery">
+          <Name>Watcher Discovery Override for 'Sample - AdventureWorks OLTP'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Override.AvailabilityWithSimpleMap.Availabilty.TestScript">
+          <Name>Web Availability Test Override for 'Sample - AdventureWorks OLTP'</Name>
+        </DisplayString>
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithSimpleMap/Overrides.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/AvailabilityWithSimpleMap/Overrides.mpx
@@ -16,6 +16,18 @@
         </Value>
       </MonitorConfigurationOverride>
 
+      <RuleConfigurationOverride ID="SquaredUp.EAM.Samples.Override.AvailabilityWithSimpleMap.Availability.PerfCollection"
+         Context="SquaredUp.EAM.Samples.Class.AvailabilityWithSimpleMap.AvailabilityMonitoringGroup"
+         Enforced="false"
+         Rule="EAM!SquaredUp.EAM.Library.Rule.AvailabilityMonitoring.Web.PerformanceCollection"
+         Module="DS"
+         Parameter="Script">
+        <Value>
+          $result = New-Object -TypeName PSobject -Property (@{'Success'=$true;'Description'='';'ResponseTime'=[double](Get-Random -Minimum 50 -Maximum 1000)})
+          return $result
+        </Value>
+      </RuleConfigurationOverride>
+
     </Overrides>
   </Monitoring>
   <LanguagePacks>
@@ -29,6 +41,9 @@
         </DisplayString>
         <DisplayString ElementID="SquaredUp.EAM.Samples.Override.AvailabilityWithSimpleMap.Availabilty.TestScript">
           <Name>Web Availability Test Override for 'Sample - AdventureWorks OLTP'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Override.AvailabilityWithSimpleMap.Availability.PerfCollection">
+          <Name>Web Availability Test Performance collection Override for 'Sample - AdventureWorks OLTP'</Name>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/CompleteEnterpriseApplication.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/CompleteEnterpriseApplication.mpx
@@ -1,0 +1,119 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <EntityTypes>
+      <ClassTypes>
+        
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication" Base="EAM!SquaredUp.EAM.Library.Class.EnterpriseApplication.v1" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+        
+        <ClassType ID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Availability" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Availability" Hosted="false" Singleton="false" Extension="false" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Map" Hosted="false" Singleton="false" Extension="false" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Dependencies" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Dependencies" Hosted="false" Singleton="false" Extension="false" />
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.AvailabilityMonitoringGroup" Accessibility="Public" Abstract="false" Base="MSIL!Microsoft.SystemCenter.InstanceGroup" Hosted="false" Singleton="true" Extension="false" /> 
+
+        <ClassType ID="EA_fe2f8e898195726e0291470a92491867_Map_04489e5f547a450cb90cf20b94bfda3b" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.MapGroup" Hosted="false" Singleton="false" Extension="false" />
+        <!-- 04489e5f-547a-450c-b90c-f20b94bfda3b -->
+        <ClassType ID="EA_fe2f8e898195726e0291470a92491867_Map_7a0c0b8da3284c4881b2720a81d7d189" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.MapGroup" Hosted="false" Singleton="false" Extension="false" />
+        <!-- 7a0c0b8d-a328-4c48-81b2-720a81d7d189 -->
+        <ClassType ID="EA_fe2f8e898195726e0291470a92491867_Map_f76e08b034fc4b0f89e40fd01a895a9f" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.MapGroup" Hosted="false" Singleton="false" Extension="false" />
+        <!-- f76e08b0-34fc-4b0f-89e4-0fd01a895a9f -->
+
+      </ClassTypes>
+
+      <RelationshipTypes>
+
+        <RelationshipType ID="EA_fe2f8e898195726e0291470a92491867_Map_Contains_04489e5f547a450cb90cf20b94bfda3b" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Relationship.Map.ContainsMapGroup">
+          <Source ID="source" MinCardinality="0" MaxCardinality="2147483647" Type="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map" />
+          <Target ID="target" MinCardinality="0" MaxCardinality="2147483647" Type="EA_fe2f8e898195726e0291470a92491867_Map_04489e5f547a450cb90cf20b94bfda3b" />
+        </RelationshipType>
+        <RelationshipType ID="EA_fe2f8e898195726e0291470a92491867_Map_04489e5f547a450cb90cf20b94bfda3b_Contains_Entity" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Relationship.MapGroup.ContainsEntity">
+          <Source ID="source" MinCardinality="0" MaxCardinality="2147483647" Type="EA_fe2f8e898195726e0291470a92491867_Map_04489e5f547a450cb90cf20b94bfda3b" />
+          <Target ID="target" MinCardinality="0" MaxCardinality="2147483647" Type="System!System.Entity" />
+        </RelationshipType>
+
+        <RelationshipType ID="EA_fe2f8e898195726e0291470a92491867_Map_Contains_7a0c0b8da3284c4881b2720a81d7d189" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Relationship.Map.ContainsMapGroup">
+          <Source ID="source" MinCardinality="0" MaxCardinality="2147483647" Type="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map" />
+          <Target ID="target" MinCardinality="0" MaxCardinality="2147483647" Type="EA_fe2f8e898195726e0291470a92491867_Map_7a0c0b8da3284c4881b2720a81d7d189" />
+        </RelationshipType>
+        <RelationshipType ID="EA_fe2f8e898195726e0291470a92491867_Map_7a0c0b8da3284c4881b2720a81d7d189_Contains_Entity" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Relationship.MapGroup.ContainsEntity">
+          <Source ID="source" MinCardinality="0" MaxCardinality="2147483647" Type="EA_fe2f8e898195726e0291470a92491867_Map_7a0c0b8da3284c4881b2720a81d7d189" />
+          <Target ID="target" MinCardinality="0" MaxCardinality="2147483647" Type="System!System.Entity" />
+        </RelationshipType>
+
+        <RelationshipType ID="EA_fe2f8e898195726e0291470a92491867_Map_Contains_f76e08b034fc4b0f89e40fd01a895a9f" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Relationship.Map.ContainsMapGroup">
+          <Source ID="source" MinCardinality="0" MaxCardinality="2147483647" Type="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map" />
+          <Target ID="target" MinCardinality="0" MaxCardinality="2147483647" Type="EA_fe2f8e898195726e0291470a92491867_Map_f76e08b034fc4b0f89e40fd01a895a9f" />
+        </RelationshipType>
+        <RelationshipType ID="EA_fe2f8e898195726e0291470a92491867_Map_f76e08b034fc4b0f89e40fd01a895a9f_Contains_Entity" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Relationship.MapGroup.ContainsEntity">
+          <Source ID="source" MinCardinality="0" MaxCardinality="2147483647" Type="EA_fe2f8e898195726e0291470a92491867_Map_f76e08b034fc4b0f89e40fd01a895a9f" />
+          <Target ID="target" MinCardinality="0" MaxCardinality="2147483647" Type="System!System.Entity" />
+        </RelationshipType>
+
+      </RelationshipTypes>
+    </EntityTypes>
+  </TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication">
+          <Name>Sample - Contoso Sales App</Name>
+          <Description>Enterprise Application 'Sample - Contoso Sales App'</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Availability">
+          <Name>Sample - Contoso Sales App Availability</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map">
+          <Name>Sample - Contoso Sales App Map</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Dependencies">
+          <Name>Sample - Contoso Sales App Dependencies</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.AvailabilityMonitoringGroup">
+          <Name>'Sample - Contoso Sales App' Availability Monitors</Name>
+        </DisplayString>
+
+
+        <DisplayString ElementID="EA_fe2f8e898195726e0291470a92491867_Map_04489e5f547a450cb90cf20b94bfda3b">
+          <Name>Web Servers</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="EA_fe2f8e898195726e0291470a92491867_Map_Contains_04489e5f547a450cb90cf20b94bfda3b">
+          <Name>Relationship in EA Sample - Contoso Sales App to include group 'Web Servers' in map.</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="EA_fe2f8e898195726e0291470a92491867_Map_04489e5f547a450cb90cf20b94bfda3b_Contains_Entity">
+          <Name>Relationship in EA Sample - Contoso Sales App to include objects in map group 'Web Servers'.</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="EA_fe2f8e898195726e0291470a92491867_Map_7a0c0b8da3284c4881b2720a81d7d189">
+          <Name>App Servers</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="EA_fe2f8e898195726e0291470a92491867_Map_Contains_7a0c0b8da3284c4881b2720a81d7d189">
+          <Name>Relationship in EA Sample - Contoso Sales App to include group 'App Servers' in map.</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="EA_fe2f8e898195726e0291470a92491867_Map_7a0c0b8da3284c4881b2720a81d7d189_Contains_Entity">
+          <Name>Relationship in EA Sample - Contoso Sales App to include objects in map group 'App Servers'.</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="EA_fe2f8e898195726e0291470a92491867_Map_f76e08b034fc4b0f89e40fd01a895a9f">
+          <Name>Database</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="EA_fe2f8e898195726e0291470a92491867_Map_Contains_f76e08b034fc4b0f89e40fd01a895a9f">
+          <Name>Relationship in EA Sample - Contoso Sales App to include group 'Database' in map.</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="EA_fe2f8e898195726e0291470a92491867_Map_f76e08b034fc4b0f89e40fd01a895a9f_Contains_Entity">
+          <Name>Relationship in EA Sample - Contoso Sales App to include objects in map group 'Database'.</Name>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Computers.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Computers.mpx
@@ -1,0 +1,57 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <EntityTypes>
+      <ClassTypes>
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleComputer.CompleteEnterpriseApplication.Web01" Base="SquaredUp.EAM.Samples.Class.SampleComputer" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleComputer.CompleteEnterpriseApplication.Web02" Base="SquaredUp.EAM.Samples.Class.SampleComputer" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleComputer.CompleteEnterpriseApplication.Web03" Base="SquaredUp.EAM.Samples.Class.SampleComputer" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleComputer.CompleteEnterpriseApplication.App01" Base="SquaredUp.EAM.Samples.Class.SampleComputer" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleComputer.CompleteEnterpriseApplication.App02" Base="SquaredUp.EAM.Samples.Class.SampleComputer" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+        
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleComputer.CompleteEnterpriseApplication.SQL01" Base="SquaredUp.EAM.Samples.Class.SampleComputer" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleComputer.CompleteEnterpriseApplication.SQL02" Base="SquaredUp.EAM.Samples.Class.SampleComputer" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+
+      </ClassTypes>
+    </EntityTypes>
+  </TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleComputer.CompleteEnterpriseApplication.Web01">
+          <Name>Sales-WEB-01.contoso.com</Name>
+          <Description>A sample object used to represent a computer within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleComputer.CompleteEnterpriseApplication.Web02">
+          <Name>Sales-WEB-02.contoso.com</Name>
+          <Description>A sample object used to represent a computer within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleComputer.CompleteEnterpriseApplication.Web03">
+          <Name>Sales-WEB-03.contoso.com</Name>
+          <Description>A sample object used to represent a computer within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleComputer.CompleteEnterpriseApplication.App01">
+          <Name>Sales-APP-01.contoso.com</Name>
+          <Description>A sample object used to represent a computer within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleComputer.CompleteEnterpriseApplication.App02">
+          <Name>Sales-APP-02.contoso.com</Name>
+          <Description>A sample object used to represent a computer within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleComputer.CompleteEnterpriseApplication.SQL01">
+          <Name>Sales-SQL-01.contoso.com</Name>
+          <Description>A sample object used to represent a computer within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleComputer.CompleteEnterpriseApplication.SQL02">
+          <Name>Sales-SQL-02.contoso.com</Name>
+          <Description>A sample object used to represent a computer within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Dependencies.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Dependencies.mpx
@@ -1,0 +1,29 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <EntityTypes>
+      <ClassTypes>
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleCloudService.CompleteEnterpriseApplication.AzureActiveDirectory" Base="SquaredUp.EAM.Samples.Class.SampleCloudService" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleCloudService.CompleteEnterpriseApplication.San" Base="SquaredUp.EAM.Samples.Class.SampleCloudService" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+
+      </ClassTypes>
+    </EntityTypes>
+  </TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleCloudService.CompleteEnterpriseApplication.AzureActiveDirectory">
+          <Name>Azure Active Directory (Contoso)</Name>
+          <Description>A sample object used to represent a cloud dependency within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleCloudService.CompleteEnterpriseApplication.San">
+          <Name>Sales App SAN Luns (Contoso)</Name>
+          <Description>A sample object used to represent a group of SAN luns in sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Discovery.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Discovery.mpx
@@ -1,0 +1,452 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Discoveries>
+
+      <Discovery ID="SquaredUp.EAM.Samples.Discovery.CompleteEnterpriseApplication.AvailabilityMonitoringGroupContainsWatchers" Enabled="true" Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.AvailabilityMonitoringGroup" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes />
+        <DataSource ID="DS" TypeID="SC!Microsoft.SystemCenter.GroupPopulator">
+          <RuleId>$MPElement$</RuleId>
+          <GroupInstanceId>$Target/Id$</GroupInstanceId>
+          <MembershipRules>
+            <MembershipRule>
+              <MonitoringClass>$MPElement[Name="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher"]$</MonitoringClass>
+              <RelationshipClass>$MPElement[Name="MSIL!Microsoft.SystemCenter.InstanceGroupContainsEntities"]$</RelationshipClass>
+              <Expression>
+                <SimpleExpression>
+                  <ValueExpression>
+                    <Property>$MPElement[Name="System!System.Entity"]/DisplayName$</Property>
+                  </ValueExpression>
+                  <Operator>Equal</Operator>
+                  <ValueExpression>
+                    <Value>Sample - Contoso Sales App</Value>
+                  </ValueExpression>
+                </SimpleExpression>
+              </Expression>
+            </MembershipRule>
+          </MembershipRules>
+        </DataSource>
+      </Discovery>
+      
+      <Discovery ID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Watcher.Discovery" Enabled="true" Target="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.MonitoringNode" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryClass TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher.Web">
+            <Property TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher" PropertyID="ConfigurationJson" />
+            <Property TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher" PropertyID="ApplicationName" />
+            <Property TypeID="EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher" PropertyID="ResponseTimeThreshold" />
+          </DiscoveryClass>
+        </DiscoveryTypes>
+        <DataSource ID="DS" TypeID="EAM!SquaredUp.EAM.Library.DataSource.AvailabilityMonitoring.StaticAlwaysOnDiscovery">
+          <IntervalSeconds>86400</IntervalSeconds>
+          <DiscoverInstance>false</DiscoverInstance>
+          <ComputerName>$Target/Host/Property[Type='Windows!Microsoft.Windows.Computer']/PrincipalName$</ComputerName>
+          <ClassId>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher.Web']$</ClassId>
+          <InstanceSettings>
+            <Settings>
+              <Setting>
+                <Name>$MPElement[Name="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Name>
+                <Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='System!System.Entity']/DisplayName$</Name>
+                <Value>Sample - Contoso Sales App</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher']/ConfigurationJson$</Name>
+                <Value>{"url":"https://sales.contoso.com","match":"","notmatch":"Error"}</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher']/ApplicationName$</Name>
+                <Value>Sample - Contoso Sales App</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.AvailabilityMonitoring.Watcher']/ResponseTimeThreshold$</Name>
+                <Value>1000</Value>
+              </Setting>
+            </Settings>
+          </InstanceSettings>
+        </DataSource>
+      </Discovery>
+
+      <Discovery ID="LocalDiscovery_EA_fe2f8e898195726e0291470a92491867" Enabled="true" Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Availability" />
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map" />
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Dependencies" />
+          <DiscoveryClass TypeID="EA_fe2f8e898195726e0291470a92491867_Map_04489e5f547a450cb90cf20b94bfda3b" />
+          <DiscoveryClass TypeID="EA_fe2f8e898195726e0291470a92491867_Map_7a0c0b8da3284c4881b2720a81d7d189" />
+          <DiscoveryClass TypeID="EA_fe2f8e898195726e0291470a92491867_Map_f76e08b034fc4b0f89e40fd01a895a9f" />
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.SampleComputer" />
+        </DiscoveryTypes>
+        <DataSource ID="DS" TypeID="EAM!SquaredUp.EAM.Library.Datasource.DiscoveryProvider">
+          <DiscoveriesJson>
+{
+    "newObjects": [
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Availability']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Availability']/ApplicationId$",
+                    "value": "fe2f8e89-8195-726e-0291-470a92491867"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - Contoso Sales App Availability"
+                }
+            ],
+            "instanceId": "inst_2",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/ApplicationId$",
+                    "value": "fe2f8e89-8195-726e-0291-470a92491867"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - Contoso Sales App Map"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/CreateServiceMonitors$",
+                    "value": "True"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/CreateTcpMonitors$",
+                    "value": "True"
+                }
+            ],
+            "instanceId": "inst_3",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Dependencies']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Dependencies']/ApplicationId$",
+                    "value": "fe2f8e89-8195-726e-0291-470a92491867"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - Contoso Sales App Dependencies"
+                }
+            ],
+            "instanceId": "inst_4",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe2f8e898195726e0291470a92491867_Map_04489e5f547a450cb90cf20b94bfda3b']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/ApplicationId$",
+                    "value": "fe2f8e89-8195-726e-0291-470a92491867"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/GroupId$",
+                    "value": "04489e5f-547a-450c-b90c-f20b94bfda3b"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Web Servers"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/HorizIndex$",
+                    "value": "0"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/VertIndex$",
+                    "value": "0"
+                }
+            ],
+            "instanceId": "inst_5",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe2f8e898195726e0291470a92491867_Map_7a0c0b8da3284c4881b2720a81d7d189']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/ApplicationId$",
+                    "value": "fe2f8e89-8195-726e-0291-470a92491867"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/GroupId$",
+                    "value": "7a0c0b8d-a328-4c48-81b2-720a81d7d189"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "App Servers"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/HorizIndex$",
+                    "value": "1"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/VertIndex$",
+                    "value": "0"
+                }
+            ],
+            "instanceId": "inst_6",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe2f8e898195726e0291470a92491867_Map_f76e08b034fc4b0f89e40fd01a895a9f']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/ApplicationId$",
+                    "value": "fe2f8e89-8195-726e-0291-470a92491867"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/GroupId$",
+                    "value": "f76e08b0-34fc-4b0f-89e4-0fd01a895a9f"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Database"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/HorizIndex$",
+                    "value": "2"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/VertIndex$",
+                    "value": "0"
+                }
+            ],
+            "instanceId": "inst_7",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        }
+    ],
+    "existingObjects": [
+        {
+            "objId": "fe2f8e89-8195-726e-0291-470a92491867",
+            "instanceId": "inst_1",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "objId": "66d8c5fd-4f32-cfc5-aff6-01bf99da8043",
+            "instanceId": "inst_8",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "objId": "e9412568-f89d-0ad3-0156-2923699c140c",
+            "instanceId": "inst_9",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+          
+        },
+        {
+            "objId": "0aa7bb87-742f-6bff-de06-422ae32ea2b1",
+            "instanceId": "inst_10",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+          
+        },
+        {
+            "objId": "9ed0ed03-42d2-c1c6-46df-bb8fcea08a0f",
+            "instanceId": "inst_11",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+          
+        },
+        {
+            "objId": "0756b48c-d674-5e63-f849-88d34c94d298",
+            "instanceId": "inst_12",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+          
+        },
+        {
+            "objId": "95b9d532-3c21-233f-a436-9be93cfb161f",
+            "instanceId": "inst_13",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+          
+        },
+        {
+            "objId": "bd037bfb-2c61-5014-988b-3a246a83a21e",
+            "instanceId": "inst_14",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+          
+        },
+        {
+            "objId": "0946a558-b220-db8f-d9a6-0316ad231219",
+            "instanceId": "inst_15",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+          
+        },
+        {
+            "objId": "3671d805-ab9d-29a8-8049-66bb95c9a274",
+            "instanceId": "inst_16",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+          
+        },
+        {
+            "objId": "f5e63045-680d-bd0d-8e99-0b07af12f0ef",
+            "instanceId": "inst_17",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+          
+        }
+    ],
+    "relationships": [
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsAvailability']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_2",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsMap']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_3",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsDependencies']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_4",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.Availability.ContainsEntity']$",
+            "sourceInstanceId": "inst_2",
+            "targetInstanceId": "inst_8",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe2f8e898195726e0291470a92491867_Map_Contains_04489e5f547a450cb90cf20b94bfda3b']$",
+            "sourceInstanceId": "inst_3",
+            "targetInstanceId": "inst_5",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe2f8e898195726e0291470a92491867_Map_04489e5f547a450cb90cf20b94bfda3b_Contains_Entity']$",
+            "sourceInstanceId": "inst_5",
+            "targetInstanceId": "inst_11",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe2f8e898195726e0291470a92491867_Map_04489e5f547a450cb90cf20b94bfda3b_Contains_Entity']$",
+            "sourceInstanceId": "inst_5",
+            "targetInstanceId": "inst_12",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe2f8e898195726e0291470a92491867_Map_04489e5f547a450cb90cf20b94bfda3b_Contains_Entity']$",
+            "sourceInstanceId": "inst_5",
+            "targetInstanceId": "inst_13",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe2f8e898195726e0291470a92491867_Map_Contains_7a0c0b8da3284c4881b2720a81d7d189']$",
+            "sourceInstanceId": "inst_3",
+            "targetInstanceId": "inst_6",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe2f8e898195726e0291470a92491867_Map_7a0c0b8da3284c4881b2720a81d7d189_Contains_Entity']$",
+            "sourceInstanceId": "inst_6",
+            "targetInstanceId": "inst_14",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe2f8e898195726e0291470a92491867_Map_7a0c0b8da3284c4881b2720a81d7d189_Contains_Entity']$",
+            "sourceInstanceId": "inst_6",
+            "targetInstanceId": "inst_15",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe2f8e898195726e0291470a92491867_Map_Contains_f76e08b034fc4b0f89e40fd01a895a9f']$",
+            "sourceInstanceId": "inst_3",
+            "targetInstanceId": "inst_7",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe2f8e898195726e0291470a92491867_Map_f76e08b034fc4b0f89e40fd01a895a9f_Contains_Entity']$",
+            "sourceInstanceId": "inst_7",
+            "targetInstanceId": "inst_16",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe2f8e898195726e0291470a92491867_Map_f76e08b034fc4b0f89e40fd01a895a9f_Contains_Entity']$",
+            "sourceInstanceId": "inst_7",
+            "targetInstanceId": "inst_17",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.MapGroup.ReferencesMapGroup']$",
+            "sourceInstanceId": "inst_5",
+            "targetInstanceId": "inst_6",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.MapGroup.ReferencesMapGroup']/TargetPortNumbers$",
+                    "value": "11111"
+                }
+            ]
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.MapGroup.ReferencesMapGroup']$",
+            "sourceInstanceId": "inst_6",
+            "targetInstanceId": "inst_7",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.MapGroup.ReferencesMapGroup']/TargetPortNumbers$",
+                    "value": "1433"
+                }
+            ]
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.Dependencies.ContainsEntity']$",
+            "sourceInstanceId": "inst_4",
+            "targetInstanceId": "inst_9",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.Dependencies.ContainsEntity']$",
+            "sourceInstanceId": "inst_4",
+            "targetInstanceId": "inst_10",
+            "properties": null
+        }
+    ]
+}
+          </DiscoveriesJson>
+          <IntervalSeconds>86400</IntervalSeconds>
+        </DataSource>
+      </Discovery>
+
+    </Discoveries>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Discovery.CompleteEnterpriseApplication.AvailabilityMonitoringGroupContainsWatchers">
+          <Name>Discovers 'Sample - Contoso Sales App' Enterprise Application Availablity Monitoring Test instances</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Watcher.Discovery">
+          <Name>Discovers 'Sample - Contoso Sales App' Enterprise Application Availability Monitoring Test (Web)</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="LocalDiscovery_EA_fe2f8e898195726e0291470a92491867">
+          <Name>Discovery to populate 'Sample - Contoso Sales App' Enterprise Application with contained monitoring objects</Name>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Discovery.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Discovery.mpx
@@ -435,7 +435,7 @@
       <DisplayStrings>
 
         <DisplayString ElementID="SquaredUp.EAM.Samples.Discovery.CompleteEnterpriseApplication.AvailabilityMonitoringGroupContainsWatchers">
-          <Name>Discovers 'Sample - Contoso Sales App' Enterprise Application Availablity Monitoring Test instances</Name>
+          <Name>Discovers 'Sample - Contoso Sales App' Enterprise Application Availability Monitoring Test instances</Name>
         </DisplayString>
 
         <DisplayString ElementID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Watcher.Discovery">

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Monitors.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Monitors.mpx
@@ -1,0 +1,226 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Monitors>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Watcher.Group.Rollup" 
+        Accessibility="Public" 
+        Enabled="true" 
+        Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.AvailabilityMonitoringGroup" 
+        ParentMonitorID="SystemHealthLibrary!System.Health.AvailabilityState" 
+        Remotable="true" 
+        Priority="Normal" 
+        RelationshipType="MSIL!Microsoft.SystemCenter.InstanceGroupContainsEntities" 
+        MemberMonitor="SystemHealthLibrary!System.Health.AvailabilityState">
+        <Category>AvailabilityHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Availability_WebServers" 
+                         Accessibility="Public" 
+                         Enabled="true" 
+                         Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map" 
+                         ParentMonitorID="SystemHealthLibrary!System.Health.AvailabilityState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe2f8e898195726e0291470a92491867_Map_Contains_04489e5f547a450cb90cf20b94bfda3b"
+                         MemberMonitor="SystemHealthLibrary!System.Health.AvailabilityState">
+        <Category>AvailabilityHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Configuration_WebServers"
+                         Accessibility="Public"
+                         Enabled="true"
+                         Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map"
+                         ParentMonitorID="SystemHealthLibrary!System.Health.ConfigurationState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe2f8e898195726e0291470a92491867_Map_Contains_04489e5f547a450cb90cf20b94bfda3b"
+                         MemberMonitor="SystemHealthLibrary!System.Health.ConfigurationState">
+        <Category>ConfigurationHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Performance_WebServers"
+                         Accessibility="Public"
+                         Enabled="true"
+                         Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map"
+                         ParentMonitorID="SystemHealthLibrary!System.Health.PerformanceState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe2f8e898195726e0291470a92491867_Map_Contains_04489e5f547a450cb90cf20b94bfda3b"
+                         MemberMonitor="SystemHealthLibrary!System.Health.PerformanceState">
+        <Category>PerformanceHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Security_WebServers"
+                         Accessibility="Public"
+                         Enabled="true"
+                         Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map"
+                         ParentMonitorID="SystemHealthLibrary!System.Health.SecurityState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe2f8e898195726e0291470a92491867_Map_Contains_04489e5f547a450cb90cf20b94bfda3b"
+                         MemberMonitor="SystemHealthLibrary!System.Health.SecurityState">
+        <Category>SecurityHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+            <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Availability_AppServers" 
+                         Accessibility="Public" 
+                         Enabled="true" 
+                         Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map" 
+                         ParentMonitorID="SystemHealthLibrary!System.Health.AvailabilityState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe2f8e898195726e0291470a92491867_Map_Contains_7a0c0b8da3284c4881b2720a81d7d189"
+                         MemberMonitor="SystemHealthLibrary!System.Health.AvailabilityState">
+        <Category>AvailabilityHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Configuration_AppServers"
+                         Accessibility="Public"
+                         Enabled="true"
+                         Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map"
+                         ParentMonitorID="SystemHealthLibrary!System.Health.ConfigurationState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe2f8e898195726e0291470a92491867_Map_Contains_7a0c0b8da3284c4881b2720a81d7d189"
+                         MemberMonitor="SystemHealthLibrary!System.Health.ConfigurationState">
+        <Category>ConfigurationHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Performance_AppServers"
+                         Accessibility="Public"
+                         Enabled="true"
+                         Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map"
+                         ParentMonitorID="SystemHealthLibrary!System.Health.PerformanceState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe2f8e898195726e0291470a92491867_Map_Contains_7a0c0b8da3284c4881b2720a81d7d189"
+                         MemberMonitor="SystemHealthLibrary!System.Health.PerformanceState">
+        <Category>PerformanceHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Security_AppServers"
+                         Accessibility="Public"
+                         Enabled="true"
+                         Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map"
+                         ParentMonitorID="SystemHealthLibrary!System.Health.SecurityState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe2f8e898195726e0291470a92491867_Map_Contains_7a0c0b8da3284c4881b2720a81d7d189"
+                         MemberMonitor="SystemHealthLibrary!System.Health.SecurityState">
+        <Category>SecurityHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+            <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Availability_Database" 
+                         Accessibility="Public" 
+                         Enabled="true" 
+                         Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map" 
+                         ParentMonitorID="SystemHealthLibrary!System.Health.AvailabilityState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe2f8e898195726e0291470a92491867_Map_Contains_f76e08b034fc4b0f89e40fd01a895a9f"
+                         MemberMonitor="SystemHealthLibrary!System.Health.AvailabilityState">
+        <Category>AvailabilityHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Configuration_Database"
+                         Accessibility="Public"
+                         Enabled="true"
+                         Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map"
+                         ParentMonitorID="SystemHealthLibrary!System.Health.ConfigurationState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe2f8e898195726e0291470a92491867_Map_Contains_f76e08b034fc4b0f89e40fd01a895a9f"
+                         MemberMonitor="SystemHealthLibrary!System.Health.ConfigurationState">
+        <Category>ConfigurationHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Performance_Database"
+                         Accessibility="Public"
+                         Enabled="true"
+                         Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map"
+                         ParentMonitorID="SystemHealthLibrary!System.Health.PerformanceState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe2f8e898195726e0291470a92491867_Map_Contains_f76e08b034fc4b0f89e40fd01a895a9f"
+                         MemberMonitor="SystemHealthLibrary!System.Health.PerformanceState">
+        <Category>PerformanceHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Security_Database"
+                         Accessibility="Public"
+                         Enabled="true"
+                         Target="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Map"
+                         ParentMonitorID="SystemHealthLibrary!System.Health.SecurityState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe2f8e898195726e0291470a92491867_Map_Contains_f76e08b034fc4b0f89e40fd01a895a9f"
+                         MemberMonitor="SystemHealthLibrary!System.Health.SecurityState">
+        <Category>SecurityHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+    </Monitors>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+      <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Watcher.Group.Rollup">
+        <Name>Availability test rollup</Name>
+      </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Availability_WebServers">
+          <Name>Availability roll-up for 'Web Servers'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Configuration_WebServers">
+          <Name>Configuration roll-up for 'Web Servers'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Performance_WebServers">
+          <Name>Performance roll-up for 'Web Servers'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Security_WebServers">
+          <Name>Security roll-up for 'Web Servers'</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Availability_AppServers">
+          <Name>Availability roll-up for 'App Servers'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Configuration_AppServers">
+          <Name>Configuration roll-up for 'App Servers'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Performance_AppServers">
+          <Name>Performance roll-up for 'App Servers'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Security_AppServers">
+          <Name>Security roll-up for 'App Servers'</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Availability_Database">
+          <Name>Availability roll-up for 'Database'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Configuration_Database">
+          <Name>Configuration roll-up for 'Database'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Performance_Database">
+          <Name>Performance roll-up for 'Database'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.CompleteEnterpriseApplication.Map_Security_Database">
+          <Name>Security roll-up for 'Database'</Name>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Overrides.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Overrides.mpx
@@ -1,0 +1,36 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Overrides>
+      <MonitorPropertyOverride ID="SquaredUp.EAM.Samples.Override.CompleteEnterpriseApplication" Context="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication" Enforced="false" Monitor="EAM!SquaredUp.EAM.Library.Monitor.ManualAvailability" Property="Enabled">
+        <Value>true</Value>
+      </MonitorPropertyOverride>
+
+      <DiscoveryConfigurationOverride ID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Override.WatcherDiscovery" Context="SquaredUp.EAM.Samples.EAM_Default"  Enforced="false" Discovery="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Watcher.Discovery" Parameter="DiscoverInstance" Module="DS">
+        <Value>true</Value>
+      </DiscoveryConfigurationOverride>
+
+      <MonitorConfigurationOverride ID="SquaredUp.EAM.Samples.Override.CompleteEnterpriseApplication.Availabilty.TestScript" Context="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.AvailabilityMonitoringGroup" Enforced="false" Monitor="EAM!SquaredUp.EAM.Library.Monitor.AvailabilityMonitoring.Web" Parameter="Script">
+        <Value>
+          $result = New-Object -TypeName PSobject -Property (@{'Success'=$true;'Description'='';'ResponseTime'=[double](Get-Random -Minimum 50 -Maximum 1000)})
+          return $result
+        </Value>
+      </MonitorConfigurationOverride>
+
+    </Overrides>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Override.CompleteEnterpriseApplication">
+          <Name>Manual Availability Override for 'Sample - Contoso Sales App'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.Override.WatcherDiscovery">
+          <Name>Watcher Discovery Override for 'Sample - Contoso Sales App'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Override.CompleteEnterpriseApplication.Availabilty.TestScript">
+          <Name>Web Availability Test Override for 'Sample - Contoso Sales App'</Name>
+        </DisplayString>
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Overrides.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Overrides.mpx
@@ -43,7 +43,7 @@
           <Name>Web Availability Test Override for 'Sample - Contoso Sales App'</Name>
         </DisplayString>
         <DisplayString ElementID="SquaredUp.EAM.Samples.Override.CompleteEnterpriseApplication.Availability.PerfCollection">
-          <Name>Web Availability Test Performance collection Override for 'Sample - Contoso Sales App'</Name>
+          <Name>Web Availability Test Performance Collection Override for 'Sample - Contoso Sales App'</Name>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Overrides.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/CompleteEnterpriseApplication/Overrides.mpx
@@ -16,6 +16,18 @@
         </Value>
       </MonitorConfigurationOverride>
 
+      <RuleConfigurationOverride ID="SquaredUp.EAM.Samples.Override.CompleteEnterpriseApplication.Availability.PerfCollection"
+         Context="SquaredUp.EAM.Samples.Class.CompleteEnterpriseApplication.AvailabilityMonitoringGroup"
+         Enforced="false"
+         Rule="EAM!SquaredUp.EAM.Library.Rule.AvailabilityMonitoring.Web.PerformanceCollection"
+         Module="DS"
+         Parameter="Script">
+        <Value>
+          $result = New-Object -TypeName PSobject -Property (@{'Success'=$true;'Description'='';'ResponseTime'=[double](Get-Random -Minimum 50 -Maximum 1000)})
+          return $result
+        </Value>
+      </RuleConfigurationOverride>
+
     </Overrides>
   </Monitoring>
   <LanguagePacks>
@@ -29,6 +41,9 @@
         </DisplayString>
         <DisplayString ElementID="SquaredUp.EAM.Samples.Override.CompleteEnterpriseApplication.Availabilty.TestScript">
           <Name>Web Availability Test Override for 'Sample - Contoso Sales App'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Override.CompleteEnterpriseApplication.Availability.PerfCollection">
+          <Name>Web Availability Test Performance collection Override for 'Sample - Contoso Sales App'</Name>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/ManualHealth/Computers.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/ManualHealth/Computers.mpx
@@ -1,0 +1,29 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <EntityTypes>
+      <ClassTypes>
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleComputer.PartsUnlimited.Web01" Base="SquaredUp.EAM.Samples.Class.SampleComputer" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.SampleComputer.PartsUnlimited.Web02" Base="SquaredUp.EAM.Samples.Class.SampleComputer" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+
+      </ClassTypes>
+    </EntityTypes>
+  </TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleComputer.PartsUnlimited.Web01">
+          <Name>PU-WEB-01.partsunlimited.com</Name>
+          <Description>A sample object used to represent a computer within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.SampleComputer.PartsUnlimited.Web02">
+          <Name>PU-WEB-02.partsunlimited.com</Name>
+          <Description>A sample object used to represent a computer within sample EAs. Instances of this class do not reflect a real object.</Description>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/ManualHealth/Discovery.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/ManualHealth/Discovery.mpx
@@ -1,0 +1,180 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Discoveries>
+
+      <Discovery ID="LocalDiscovery_EA_fe49b78867f8a74afc9837cec450f74f" Enabled="true" Target="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Availability" />
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Map" />
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Dependencies" />
+          <DiscoveryClass TypeID="EA_fe49b78867f8a74afc9837cec450f74f_Map_b8579d6fa6ec2b31f342ac63ad2fc32e" />
+          <DiscoveryClass TypeID="SquaredUp.EAM.Samples.Class.SampleComputer" />
+        </DiscoveryTypes>
+        <DataSource ID="DS" TypeID="EAM!SquaredUp.EAM.Library.Datasource.DiscoveryProvider">
+          <DiscoveriesJson>
+{
+    "newObjects": [
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Availability']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Availability']/ApplicationId$",
+                    "value": "fe49b788-67f8-a74a-fc98-37cec450f74f"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - Parts Unlimited Availability"
+                }
+            ],
+            "instanceId": "inst_2",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Map']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/ApplicationId$",
+                    "value": "fe49b788-67f8-a74a-fc98-37cec450f74f"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - Parts Unlimited Map"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/CreateServiceMonitors$",
+                    "value": "True"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Map']/CreateTcpMonitors$",
+                    "value": "True"
+                }
+            ],
+            "instanceId": "inst_3",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Dependencies']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.Dependencies']/ApplicationId$",
+                    "value": "fe49b788-67f8-a74a-fc98-37cec450f74f"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Sample - Parts Unlimited Dependencies"
+                }
+            ],
+            "instanceId": "inst_4",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe49b78867f8a74afc9837cec450f74f_Map_b8579d6fa6ec2b31f342ac63ad2fc32e']$",
+            "properties": [
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/ApplicationId$",
+                    "value": "fe49b788-67f8-a74a-fc98-37cec450f74f"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/GroupId$",
+                    "value": "b8579d6f-a6ec-2b31-f342-ac63ad2fc32e"
+                },
+                {
+                    "propertyId": "$MPElement[Name='System!System.Entity']/DisplayName$",
+                    "value": "Servers"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/HorizIndex$",
+                    "value": "0"
+                },
+                {
+                    "propertyId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Class.MapGroup']/VertIndex$",
+                    "value": "0"
+                }
+            ],
+            "instanceId": "inst_5",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        }
+    ],
+    "existingObjects": [
+        {
+            "objId": "fe49b788-67f8-a74a-fc98-37cec450f74f",
+            "instanceId": "inst_1",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "objId": "4dc2cf29-dfc9-012d-9ece-b51d4f23fd5c",
+            "instanceId": "inst_6",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        },
+        {
+            "objId": "cd5d8514-8188-1bd7-6671-5782285b205e",
+            "instanceId": "inst_7",
+            "serverId": "00000000-0000-0000-0000-000000000000",
+            "serverName": null
+        }
+    ],
+    "relationships": [
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsAvailability']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_2",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsMap']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_3",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EAM!SquaredUp.EAM.Library.Relationship.EnterpriseApplication.ContainsDependencies']$",
+            "sourceInstanceId": "inst_1",
+            "targetInstanceId": "inst_4",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe49b78867f8a74afc9837cec450f74f_Map_Contains_b8579d6fa6ec2b31f342ac63ad2fc32e']$",
+            "sourceInstanceId": "inst_3",
+            "targetInstanceId": "inst_5",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe49b78867f8a74afc9837cec450f74f_Map_b8579d6fa6ec2b31f342ac63ad2fc32e_Contains_Entity']$",
+            "sourceInstanceId": "inst_5",
+            "targetInstanceId": "inst_6",
+            "properties": null
+        },
+        {
+            "typeId": "$MPElement[Name='EA_fe49b78867f8a74afc9837cec450f74f_Map_b8579d6fa6ec2b31f342ac63ad2fc32e_Contains_Entity']$",
+            "sourceInstanceId": "inst_5",
+            "targetInstanceId": "inst_7",
+            "properties": null
+        }
+    ]
+}
+          </DiscoveriesJson>
+          <IntervalSeconds>86400</IntervalSeconds>
+        </DataSource>
+      </Discovery>
+
+    </Discoveries>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="LocalDiscovery_EA_fe49b78867f8a74afc9837cec450f74f">
+          <Name>Discovery to populate 'Sample - Parts Unlimited' Enterprise Application with contained monitoring objects</Name>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>         
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/ManualHealth/ManualReportingWithSimpleMap.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/ManualHealth/ManualReportingWithSimpleMap.mpx
@@ -1,0 +1,65 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <EntityTypes>
+      <ClassTypes>
+        
+
+        <ClassType ID="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap" Base="EAM!SquaredUp.EAM.Library.Class.EnterpriseApplication.v1" Accessibility="Public" Abstract="false" Hosted="false" Singleton="true" />
+        
+        <ClassType ID="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Availability" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Availability" Hosted="false" Singleton="false" Extension="false" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Map" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Map" Hosted="false" Singleton="false" Extension="false" />
+        <ClassType ID="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Dependencies" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.Dependencies" Hosted="false" Singleton="false" Extension="false" />
+
+        <ClassType ID="EA_fe49b78867f8a74afc9837cec450f74f_Map_b8579d6fa6ec2b31f342ac63ad2fc32e" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Class.MapGroup" Hosted="false" Singleton="false" Extension="false" />
+      
+      </ClassTypes>
+
+      <RelationshipTypes>
+
+        <RelationshipType ID="EA_fe49b78867f8a74afc9837cec450f74f_Map_Contains_b8579d6fa6ec2b31f342ac63ad2fc32e" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Relationship.Map.ContainsMapGroup">
+          <Source ID="source" MinCardinality="0" MaxCardinality="2147483647" Type="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Map" />
+          <Target ID="target" MinCardinality="0" MaxCardinality="2147483647" Type="EA_fe49b78867f8a74afc9837cec450f74f_Map_b8579d6fa6ec2b31f342ac63ad2fc32e" />
+        </RelationshipType>
+        <RelationshipType ID="EA_fe49b78867f8a74afc9837cec450f74f_Map_b8579d6fa6ec2b31f342ac63ad2fc32e_Contains_Entity" Accessibility="Public" Abstract="false" Base="EAM!SquaredUp.EAM.Library.Relationship.MapGroup.ContainsEntity">
+          <Source ID="source" MinCardinality="0" MaxCardinality="2147483647" Type="EA_fe49b78867f8a74afc9837cec450f74f_Map_b8579d6fa6ec2b31f342ac63ad2fc32e" />
+          <Target ID="target" MinCardinality="0" MaxCardinality="2147483647" Type="System!System.Entity" />
+        </RelationshipType>
+
+      </RelationshipTypes>
+    </EntityTypes>
+  </TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap">
+          <Name>Sample - Parts Unlimited</Name>
+          <Description>Enterprise Application 'Sample - Parts Unlimited'</Description>
+        </DisplayString>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Availability">
+          <Name>Sample - Parts Unlimited Availability</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Map">
+          <Name>Sample - Parts Unlimited Map</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Dependencies">
+          <Name>Sample - Parts Unlimited Dependencies</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="EA_fe49b78867f8a74afc9837cec450f74f_Map_b8579d6fa6ec2b31f342ac63ad2fc32e">
+          <Name>Servers</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="EA_fe49b78867f8a74afc9837cec450f74f_Map_Contains_b8579d6fa6ec2b31f342ac63ad2fc32e">
+          <Name>Relationship in EA Sample - Parts Unlimited to include group 'servers' in map.</Name>
+        </DisplayString>
+
+        <DisplayString ElementID="EA_fe49b78867f8a74afc9837cec450f74f_Map_b8579d6fa6ec2b31f342ac63ad2fc32e_Contains_Entity">
+          <Name>Relationship in EA Sample - Parts Unlimited to include objects in map group 'servers'.</Name>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/ManualHealth/Monitors.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/ManualHealth/Monitors.mpx
@@ -1,0 +1,78 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Monitors>
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.ManualReportingWithSimpleMap.Map_AvailabilityHealth_HealthMonitor" 
+                         Accessibility="Public" 
+                         Enabled="true" 
+                         Target="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Map" 
+                         ParentMonitorID="SystemHealthLibrary!System.Health.AvailabilityState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe49b78867f8a74afc9837cec450f74f_Map_Contains_b8579d6fa6ec2b31f342ac63ad2fc32e"
+                         MemberMonitor="SystemHealthLibrary!System.Health.AvailabilityState">
+        <Category>AvailabilityHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.ManualReportingWithSimpleMap.Map_ConfigurationHealth_HealthMonitor"
+                         Accessibility="Public"
+                         Enabled="true"
+                         Target="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Map"
+                         ParentMonitorID="SystemHealthLibrary!System.Health.ConfigurationState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe49b78867f8a74afc9837cec450f74f_Map_Contains_b8579d6fa6ec2b31f342ac63ad2fc32e"
+                         MemberMonitor="SystemHealthLibrary!System.Health.ConfigurationState">
+        <Category>ConfigurationHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.ManualReportingWithSimpleMap.Map_PerformanceHealth_HealthMonitor"
+                         Accessibility="Public"
+                         Enabled="true"
+                         Target="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Map"
+                         ParentMonitorID="SystemHealthLibrary!System.Health.PerformanceState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe49b78867f8a74afc9837cec450f74f_Map_Contains_b8579d6fa6ec2b31f342ac63ad2fc32e"
+                         MemberMonitor="SystemHealthLibrary!System.Health.PerformanceState">
+        <Category>PerformanceHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+
+      <DependencyMonitor ID="SquaredUp.EAM.Samples.Monitor.ManualReportingWithSimpleMap.Map_SecurityHealth_HealthMonitor"
+                         Accessibility="Public"
+                         Enabled="true"
+                         Target="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap.Map"
+                         ParentMonitorID="SystemHealthLibrary!System.Health.SecurityState"
+                         Remotable="true"
+                         Priority="Normal"
+                         RelationshipType="EA_fe49b78867f8a74afc9837cec450f74f_Map_Contains_b8579d6fa6ec2b31f342ac63ad2fc32e"
+                         MemberMonitor="SystemHealthLibrary!System.Health.SecurityState">
+        <Category>SecurityHealth</Category>
+        <Algorithm>WorstOf</Algorithm>
+      </DependencyMonitor>
+      
+    </Monitors>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.ManualReportingWithSimpleMap.Map_AvailabilityHealth_HealthMonitor">
+          <Name>Availability roll-up for 'Servers'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.ManualReportingWithSimpleMap.Map_ConfigurationHealth_HealthMonitor">
+          <Name>Configuration roll-up for 'Servers'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.ManualReportingWithSimpleMap.Map_PerformanceHealth_HealthMonitor">
+          <Name>Performance roll-up for 'Servers'</Name>
+        </DisplayString>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Monitor.ManualReportingWithSimpleMap.Map_SecurityHealth_HealthMonitor">
+          <Name>Security roll-up for 'Servers'</Name>
+        </DisplayString>
+
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/ManualHealth/Overrides.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SampleEAs/ManualHealth/Overrides.mpx
@@ -1,0 +1,18 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Overrides>
+      <MonitorPropertyOverride ID="SquaredUp.EAM.Samples.Override.ManualReportingWithSimpleMap" Context="SquaredUp.EAM.Samples.Class.ManualReportingWithSimpleMap" Enforced="false" Monitor="EAM!SquaredUp.EAM.Library.Monitor.ManualAvailability" Property="Enabled">
+        <Value>true</Value>
+      </MonitorPropertyOverride>
+    </Overrides>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        <DisplayString ElementID="SquaredUp.EAM.Samples.Override.ManualReportingWithSimpleMap">
+          <Name>Manual Availability Override for 'Sample - Parts Unlimited'</Name>
+        </DisplayString>
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/SquaredUp.EAM.Samples/Scripts/FakeComputerData.ps1
+++ b/ManagementPacks/SquaredUp.EAM.Samples/Scripts/FakeComputerData.ps1
@@ -1,0 +1,32 @@
+﻿$scomApi = New-Object -comObject MOM.ScriptAPI
+
+$results = @( 
+	(New-Object –TypeName PSObject –Prop (@{'Name'='PU-WEB-01.partsunlimited.com'; 'CPU'=(Get-Random -Minimum 30 -Maximum 75); 'Memory'=(Get-Random -Minimum 45 -Maximum 60); 'Connections'=(Get-Random -Minimum 20 -Maximum 60); 'Status'='Healthy'})),
+	(New-Object –TypeName PSObject –Prop (@{'Name'='PU-WEB-02.partsunlimited.com'; 'CPU'=(Get-Random -Minimum 30 -Maximum 75); 'Memory'=(Get-Random -Minimum 60 -Maximum 90); 'Connections'=(Get-Random -Minimum 70 -Maximum 93); 'Status'='Unhealthy'})),
+	(New-Object –TypeName PSObject –Prop (@{'Name'='AW-WEB-01.AdventureWorks.com'; 'CPU'=(Get-Random -Minimum 30 -Maximum 75); 'Memory'=(Get-Random -Minimum 40 -Maximum 60); 'Connections'=(Get-Random -Minimum 20 -Maximum 84); 'Status'='Healthy'})),
+	(New-Object –TypeName PSObject –Prop (@{'Name'='AW-SQL-01.AdventureWorks.com'; 'CPU'=(Get-Random -Minimum 95 -Maximum 100); 'Memory'=(Get-Random -Minimum 40 -Maximum 60); 'Connections'=(Get-Random -Minimum 20 -Maximum 87); 'Status'='Unhealthy'})),
+	(New-Object –TypeName PSObject –Prop (@{'Name'='Sales-WEB-01.contoso.com'; 'CPU'=(Get-Random -Minimum 30 -Maximum 75); 'Memory'=(Get-Random -Minimum 40 -Maximum 60); 'Connections'=(Get-Random -Minimum 20 -Maximum 84); 'Status'='Healthy'})),
+	(New-Object –TypeName PSObject –Prop (@{'Name'='Sales-WEB-02.contoso.com'; 'CPU'=(Get-Random -Minimum 30 -Maximum 100); 'Memory'=(Get-Random -Minimum 40 -Maximum 60); 'Connections'=(Get-Random -Minimum 20 -Maximum 87); 'Status'='Unhealthy'})),
+	(New-Object –TypeName PSObject –Prop (@{'Name'='Sales-WEB-03.contoso.com'; 'CPU'=(Get-Random -Minimum 10 -Maximum 40); 'Memory'=(Get-Random -Minimum 20 -Maximum 40); 'Connections'=(Get-Random -Minimum 0 -Maximum 10); 'Status'='Healthy'})),
+	(New-Object –TypeName PSObject –Prop (@{'Name'='Sales-APP-01.contoso.com'; 'CPU'=(Get-Random -Minimum 30 -Maximum 80); 'Memory'=(Get-Random -Minimum 40 -Maximum 60); 'Connections'=(Get-Random -Minimum 20 -Maximum 87); 'Status'='Healthy'})),
+	(New-Object –TypeName PSObject –Prop (@{'Name'='Sales-APP-02.contoso.com'; 'CPU'=(Get-Random -Minimum 30 -Maximum 75); 'Memory'=(Get-Random -Minimum 40 -Maximum 60); 'Connections'=(Get-Random -Minimum 20 -Maximum 84); 'Status'='Unhealthy'})),
+	(New-Object –TypeName PSObject –Prop (@{'Name'='Sales-SQL-01.contoso.com'; 'CPU'=(Get-Random -Minimum 55 -Maximum 75); 'Memory'=(Get-Random -Minimum 40 -Maximum 60); 'Connections'=(Get-Random -Minimum 20 -Maximum 50); 'Status'='Health'})),
+	(New-Object –TypeName PSObject –Prop (@{'Name'='Sales-SQL-02.contoso.com'; 'CPU'=(Get-Random -Minimum 95 -Maximum 100); 'Memory'=(Get-Random -Minimum 90 -Maximum 100); 'Connections'=(Get-Random -Minimum 50 -Maximum 99); 'Status'='Unhealthy'})),
+	(New-Object –TypeName PSObject –Prop (@{'Name'='Azure Active Directory (SmartHotel 360)'; 'Status'='Health'})),
+	(New-Object –TypeName PSObject –Prop (@{'Name'='SmartHotel Azure Cloud Service'; 'Status'='Unhealthy'})),
+	(New-Object –TypeName PSObject –Prop (@{'Name'='Azure Active Directory (Contoso)'; 'Status'='Health'})),
+	(New-Object –TypeName PSObject –Prop (@{'Name'='Sales App SAN Luns (Contoso)'; 'Status'='Unhealthy'}))
+)
+
+# Create bags for each object
+Foreach ($result in $results) {
+
+	$bag = $scomApi.CreatePropertyBag()
+
+	Foreach ($prop in $result.PSObject.Properties) {
+		$bag.AddValue( $prop.Name, $prop.Value )
+	}
+	# Return property bag
+	$bag
+
+}

--- a/ManagementPacks/SquaredUp.EAM.Samples/SquaredUp.EAM.Samples.mpproj
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SquaredUp.EAM.Samples.mpproj
@@ -1,0 +1,187 @@
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <ProjectGuid>{bdf8db8d-9ff6-42a2-8949-ce05796ede38}</ProjectGuid>
+    <RootNamespace>SquaredUp.EAM.Samples</RootNamespace>
+    <Name>SquaredUp.EAM.Samples</Name>
+    <ManagementPackName>SquaredUp.EAM.Samples</ManagementPackName>
+    <Version>1.0.0.0</Version>
+    <MpFrameworkVersion>v7.0</MpFrameworkVersion>
+    <MpFrameworkProfile>OM</MpFrameworkProfile>
+    <ProductVersion>1.1.0.0</ProductVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <GenerateSealed>True</GenerateSealed>
+    <Company>Squared Up Ltd.</Company>
+    <Copyright>Copyright (c) Squared Up Ltd. All rights reserved.</Copyright>
+    <DelaySigning>False</DelaySigning>
+    <AssemblyOriginatorKeyFile>..\SquaredUp.EAM.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>false</DebugSymbols>
+    <OutputPath>bin\Release\</OutputPath>
+    <DelaySigning>False</DelaySigning>
+    <Company>Squared Up Ltd.</Company>
+    <Copyright>Copyright (c) Squared Up Ltd. All rights reserved.</Copyright>
+    <DelaySign>false</DelaySign>
+    <AssemblyOriginatorKeyFile>..\SquaredUp.EAM.snk</AssemblyOriginatorKeyFile>
+    <GenerateSealed>True</GenerateSealed>
+  </PropertyGroup>
+  <ItemGroup>
+    <ManagementPackReference Include="Microsoft.SystemCenter.DataWarehouse.Library">
+      <Alias>MSDL</Alias>
+      <PackageToBundle>False</PackageToBundle>
+    </ManagementPackReference>
+    <ManagementPackReference Include="Microsoft.SystemCenter.InstanceGroup.Library">
+      <Alias>MSIL</Alias>
+      <PackageToBundle>False</PackageToBundle>
+    </ManagementPackReference>
+    <ManagementPackReference Include="Microsoft.SystemCenter.Library">
+      <Alias>SC</Alias>
+      <PackageToBundle>False</PackageToBundle>
+    </ManagementPackReference>
+    <ManagementPackReference Include="Microsoft.Windows.Library">
+      <Alias>Windows</Alias>
+      <PackageToBundle>False</PackageToBundle>
+    </ManagementPackReference>
+    <ManagementPackReference Include="System.Health.Library">
+      <Alias>SystemHealthLibrary</Alias>
+      <PackageToBundle>False</PackageToBundle>
+    </ManagementPackReference>
+    <ManagementPackReference Include="System.Library">
+      <Alias>System</Alias>
+      <PackageToBundle>False</PackageToBundle>
+    </ManagementPackReference>
+    <ManagementPackReference Include="Microsoft.SystemCenter.Visualization.Library">
+      <Alias>Visualization</Alias>
+      <PackageToBundle>false</PackageToBundle>
+    </ManagementPackReference>
+    <ManagementPackReference Include="System.Performance.Library">
+      <Alias>Perf</Alias>
+      <PackageToBundle>False</PackageToBundle>
+    </ManagementPackReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="FakeClasses" />
+    <Folder Include="Moduiles" />
+    <Folder Include="SampleEAs\AvailabilityOnly" />
+    <Folder Include="SampleEAs\AvailabilityWithDependencies" />
+    <Folder Include="SampleEAs\AvailabilityWithSimpleMap" />
+    <Folder Include="SampleEAs\CompleteEnterpriseApplication" />
+    <Folder Include="Scripts" />
+    <Folder Include="SampleEAs" />
+    <Folder Include="SampleEAs\ManualHealth" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SquaredUp.EAM.Library\SquaredUp.EAM.Library.mpproj">
+      <Name>SquaredUp.EAM.Library</Name>
+      <Project>{196967a7-da6a-4983-a3eb-3390ad065a31}</Project>
+      <Private>True</Private>
+      <Alias>EAM</Alias>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="FakeClasses\AvailabilityWatcherGroup.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="FakeClasses\Monitoring.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="FakeClasses\SampleComputer.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="FakeClasses\SampleDependency.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="ManagementPack.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Moduiles\FakeDataSource.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Moduiles\SampleComputerUnitMonitor.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\AvailabilityOnly\AvailabilityOnly.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\AvailabilityOnly\Discovery.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\AvailabilityOnly\Monitors.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\AvailabilityOnly\Overrides.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\AvailabilityWithDependencies\AvailabilityWithDependencies.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\AvailabilityWithDependencies\CloudObjects.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\AvailabilityWithDependencies\Discovery.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\AvailabilityWithDependencies\Monitors.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\AvailabilityWithDependencies\Overrides.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\AvailabilityWithSimpleMap\AvailabilityWithSimpleMap.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\AvailabilityWithSimpleMap\Computers.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\AvailabilityWithSimpleMap\Discovery.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\AvailabilityWithSimpleMap\Monitors.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\AvailabilityWithSimpleMap\Overrides.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\CompleteEnterpriseApplication\CompleteEnterpriseApplication.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\CompleteEnterpriseApplication\Computers.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\CompleteEnterpriseApplication\Dependencies.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\CompleteEnterpriseApplication\Discovery.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\CompleteEnterpriseApplication\Monitors.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\CompleteEnterpriseApplication\Overrides.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\ManualHealth\Computers.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\ManualHealth\Discovery.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\ManualHealth\ManualReportingWithSimpleMap.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\ManualHealth\Monitors.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="SampleEAs\ManualHealth\Overrides.mpx">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Scripts\FakeComputerData.ps1" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VSAC\Microsoft.SystemCenter.OperationsManager.targets" />
+</Project>


### PR DESCRIPTION
This management pack includes fake "sample" management pack that can be imported to demonstrate what a variety of Enterprise applications could look like, and demonstrate SquaredUp EAM features.

All actual monitoring data is completely fake and is produced by a single cooked down PowerShell script that provides fixed health and random performance data we control. Availability monitoring looks real in the product but I've actually used the watcher override feature in the management pack to modify the web test scripts to produce canned data.

Note the huge number of singletons is to deal with a limitation within SquaredUp's EA loading code, that at this time only supports the loading of certain types of classes within discovery JSON map parsing routine.

No additional SCOM configuration is required to use this MP - upon import all sample EA instances will automatically begin discovery and start to populate with data.  All sample EAs are prefixed with "Sample - " in their display names (but are otherwise indistinguishable from standard EAs).

Note that the naming structure is a bit all over the place in the MP - this is because certain elements _have_ to follow the naming convention specified by SquaredUp's EA loading code. This is why you'll see GUIDs or some elements clearly using the wrong type prefix ("class" rather than "discovery") in their element Ids.