### PR TITLE
Samples Management pack now depends on a known fixed version of the library, rather than most recent

### DIFF
--- a/ManagementPacks/SquaredUp.EAM.Library/SquaredUp.EAM.Library.mpproj
+++ b/ManagementPacks/SquaredUp.EAM.Library/SquaredUp.EAM.Library.mpproj
@@ -6,7 +6,7 @@
     <RootNamespace>SquaredUp.EAM.Library</RootNamespace>
     <Name>SquaredUp.EAM.Library</Name>
     <ManagementPackName>SquaredUp.EAM.Library</ManagementPackName>
-    <Version>1.0.0.0</Version>
+    <Version>1.2.5.0</Version>
     <MpFrameworkVersion>v7.0</MpFrameworkVersion>
     <MpFrameworkProfile>OM</MpFrameworkProfile>
     <ProductVersion>1.1.0.0</ProductVersion>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SquaredUp.EAM.Samples.mpproj
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SquaredUp.EAM.Samples.mpproj
@@ -5,7 +5,7 @@
     <RootNamespace>SquaredUp.EAM.Samples</RootNamespace>
     <Name>SquaredUp.EAM.Samples</Name>
     <ManagementPackName>SquaredUp.EAM.Samples</ManagementPackName>
-    <Version>1.0.0.0</Version>
+    <Version>1.1.1.0</Version>
     <MpFrameworkVersion>v7.0</MpFrameworkVersion>
     <MpFrameworkProfile>OM</MpFrameworkProfile>
     <ProductVersion>1.1.0.0</ProductVersion>
@@ -80,6 +80,7 @@
       <Project>{196967a7-da6a-4983-a3eb-3390ad065a31}</Project>
       <Private>True</Private>
       <Alias>EAM</Alias>
+      <MinVersion>1.2.5.0</MinVersion>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/ManagementPacks/SquaredUp.EAM.Samples/SquaredUp.EAM.Samples.mpproj
+++ b/ManagementPacks/SquaredUp.EAM.Samples/SquaredUp.EAM.Samples.mpproj
@@ -5,7 +5,7 @@
     <RootNamespace>SquaredUp.EAM.Samples</RootNamespace>
     <Name>SquaredUp.EAM.Samples</Name>
     <ManagementPackName>SquaredUp.EAM.Samples</ManagementPackName>
-    <Version>1.1.1.0</Version>
+    <Version>1.0.0.0</Version>
     <MpFrameworkVersion>v7.0</MpFrameworkVersion>
     <MpFrameworkProfile>OM</MpFrameworkProfile>
     <ProductVersion>1.1.0.0</ProductVersion>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,9 +73,9 @@
                           createLogFile: true
 
                       - task: MSBuild@1
-                        displayName: 'Build Library MP'
+                        displayName: 'Build Samples MP'
                         inputs:
-                          solution: '$(buildsolutionFile2)'
+                          solution: '$(buildsolutionFile3)'
                           platform: '$(buildPlatform)'
                           configuration: '$(buildConfiguration)'
                           msbuildArguments: '/p:Version=$(EAM_MAJOR_VERSION).$(EAM_MINOR_VERSION).$(EAM_REVISION).$(BUILD_NUMBER) /p:AssemblyOriginatorKeyFile=$(STRONGNAME_KEY.secureFilePath)'
@@ -83,9 +83,9 @@
                           createLogFile: true
 
                       - task: MSBuild@1
-                        displayName: 'Build Samples MP'
+                        displayName: 'Build Library MP'
                         inputs:
-                          solution: '$(buildsolutionFile3)'
+                          solution: '$(buildsolutionFile2)'
                           platform: '$(buildPlatform)'
                           configuration: '$(buildConfiguration)'
                           msbuildArguments: '/p:Version=$(EAM_MAJOR_VERSION).$(EAM_MINOR_VERSION).$(EAM_REVISION).$(BUILD_NUMBER) /p:AssemblyOriginatorKeyFile=$(STRONGNAME_KEY.secureFilePath)'


### PR DESCRIPTION
Unfortunately during the addition of the Samples MP we did not specify a minimum version of the library that the MP depends upon. This means although we only need 1.2.5 features, we force consumers to update the EAM library unnecessarily, since there are no changes.

I've also modified the build order to ensure that the Library is build last, so that artefact extraction collects each MP with the version number as it wishes to be built with.