### PR TITLE
SQ-4714: Fix TCP monitor typo

### DIFF
--- a/ManagementPacks/SquaredUp.EAM.Library/Monitoring/MonitorTypes/MonitorType.TcpProbe.mpx
+++ b/ManagementPacks/SquaredUp.EAM.Library/Monitoring/MonitorTypes/MonitorType.TcpProbe.mpx
@@ -81,7 +81,7 @@
               </Node>
             </OnDemandDetection>
             <OnDemandDetection MonitorTypeStateID="ConnectionFailed">
-              <Node ID="CDConnectionOk">
+              <Node ID="CDConnectionFailed">
                 <Node ID="Probe" />
               </Node>
             </OnDemandDetection>


### PR DESCRIPTION
As per analysis done by @shadeon , there was a typo in the On Demand Detection configuration for the TCP probe monitor, which caused erroneous alerts when the hosted object was taken out of maintenance mode or health was recalculated manually. This PR fixes the typo.