### PR TITLE
SQ-5080 SCOM EA MP to Fix the Report Availability Functionality

### DIFF
--- a/ManagementPacks/SquaredUp.EAM.Library/ManualAvailability/SquaredUp.EAM.Library.WriteAction.ManualAvailability.StartEventTask.ps1
+++ b/ManagementPacks/SquaredUp.EAM.Library/ManualAvailability/SquaredUp.EAM.Library.WriteAction.ManualAvailability.StartEventTask.ps1
@@ -27,7 +27,12 @@ $overrides = @{
 }
 
 $momapi.LogScriptEvent($scriptName,8998,0,"Triggering task to set health for '$DisplayName'")
-$taskOut = Start-SCOMTask -task $task -instance $ms -Override $overrides
+try {
+    $taskOut = Start-SCOMTask -Task $task -Instance $ms -Override $overrides -TaskCredentials $null
+}
+catch {
+    $momapi.LogScriptEvent($scriptName,8998,0,"06 `nError: $_")
+}
 
 if ($taskOut.BatchId -ne $null){
 


### PR DESCRIPTION
The `-TaskCredentials` parameter is required to be passed with the SCOM `Start-SCOMTask` cmdlet.

As per the 2022 documentation, the `-TaskCredentials` parameter is now a mandatory parameter.  If you specify a null value, Operations Manager uses the default TaskCredentials of the account for the current user.  In prior versions, if you did not specify this parameter, the default was the account for the current user.

2022:
https://learn.microsoft.com/en-us/powershell/module/operationsmanager/start-scomtask?view=systemcenter-ps-2022

2019:
https://learn.microsoft.com/en-us/powershell/module/operationsmanager/start-scomtask?view=systemcenter-ps-2019